### PR TITLE
feat(cli): Add optimism startup code and basic cli options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,8 +338,6 @@ dependencies = [
  "jemallocator",
  "reth",
  "reth-node-optimism",
- "reth-rpc-api",
- "reth-rpc-types",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,6 @@ reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "82b6504", featu
 reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "82b6504" }
 reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "82b6504" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "82b6504" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "82b6504" }
-reth-rpc-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "82b6504" }
 
 # revm
 revm = { version = "7.1.0", features = ["std", "secp256k1"], default-features = false }

--- a/bin/alphanet/Cargo.toml
+++ b/bin/alphanet/Cargo.toml
@@ -16,8 +16,6 @@ alphanet-node.workspace = true
 tracing.workspace = true
 reth.workspace = true
 reth-node-optimism.workspace = true
-reth-rpc-api.workspace = true
-reth-rpc-types.workspace = true
 clap = { workspace = true, features = ["derive"] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/bin/alphanet/src/main.rs
+++ b/bin/alphanet/src/main.rs
@@ -5,10 +5,13 @@
 
 use alphanet_node::node::AlphaNetNode;
 use clap::Parser;
-use reth::{builder::NodeHandle, cli::Cli, providers::BlockReaderIdExt};
+use reth::{
+    builder::NodeHandle,
+    cli::Cli,
+    providers::BlockReaderIdExt,
+    rpc::{api::EngineApiClient, types::engine::ForkchoiceState},
+};
 use reth_node_optimism::{args::RollupArgs, OptimismEngineTypes, OptimismNode};
-use reth_rpc_api::EngineApiClient;
-use reth_rpc_types::engine::ForkchoiceState;
 
 // We use jemalloc for performance reasons.
 #[cfg(all(feature = "jemalloc", unix))]


### PR DESCRIPTION
Fixes #21

Need this to unblock a basic testnet, since it lets us provide a genesis file. This copies the optimism node `main.rs` but uses the `AlphanetNode` types. Will add a default genesis file in a followup.