### PR TITLE
docs: add links and more descriptions in crate docs

### DIFF
--- a/bin/alphanet/Cargo.toml
+++ b/bin/alphanet/Cargo.toml
@@ -28,7 +28,7 @@ default = [
   "reth-node-optimism/optimism",
 ]
 
-asm-keccak = []
+asm-keccak = ["reth/asm-keccak"]
 
 jemalloc = ["dep:tikv-jemallocator"]
 jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]

--- a/bin/alphanet/src/main.rs
+++ b/bin/alphanet/src/main.rs
@@ -3,6 +3,25 @@
 //! Reth AlphaNet is a testnet OP Stack rollup aimed at enabling experimentation of bleeding edge
 //! Ethereum Research. It aims to showcase how Reth's pluggable and modularized architecture can
 //! serve as a distribution channel for research ideas.
+//!
+//! ## Feature Flags
+//!
+//! - `jemalloc`: Uses [jemallocator](https://github.com/tikv/jemallocator) as the global allocator.
+//!   This is **not recommended on Windows**. See [here](https://rust-lang.github.io/rfcs/1974-global-allocators.html#jemalloc)
+//!   for more info.
+//! - `jemalloc-prof`: Enables [jemallocator's](https://github.com/tikv/jemallocator) heap profiling
+//!   and leak detection functionality. See [jemalloc's opt.prof](https://jemalloc.net/jemalloc.3.html#opt.prof)
+//!   documentation for usage details. This is **not recommended on Windows**. See [here](https://rust-lang.github.io/rfcs/1974-global-allocators.html#jemalloc)
+//!   for more info.
+//! - `asm-keccak`: replaces the default, pure-Rust implementation of Keccak256 with one implemented
+//!   in assembly; see [the `keccak-asm` crate](https://github.com/DaniPopes/keccak-asm) for more
+//!   details and supported targets
+//! - `min-error-logs`: Disables all logs below `error` level.
+//! - `min-warn-logs`: Disables all logs below `warn` level.
+//! - `min-info-logs`: Disables all logs below `info` level. This can speed up the node, since fewer
+//!   calls to the logging component is made.
+//! - `min-debug-logs`: Disables all logs below `debug` level.
+//! - `min-trace-logs`: Disables all logs below `trace` level.
 
 #![warn(unused_crate_dependencies)]
 

--- a/crates/instructions/src/lib.rs
+++ b/crates/instructions/src/lib.rs
@@ -1,15 +1,25 @@
 //! # AlphaNet instructions
 //!
-//! Collection of custom OP codes for AlphaNet and related functionality.
+//! Collection of custom opcodes for AlphaNet and related functionality.
+//!
+//! This currently implements the following EIPs:
+//! - [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074): `AUTH` and `AUTHCALL` instructions. The
+//! implementation is located in the [eip3074] module. The custom instruction context required for
+//! `AUTH` and `AUTHCALL` is located in the [context] module.
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use revm_interpreter::opcode::BoxedInstruction;
 
+/// This contains the custom instruction context required for `AUTH` and `AUTHCALL` instructions,
+/// notably for the `authorized` context variable.
 pub mod context;
+
+/// The implementation of [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074): `AUTH` and
+/// `AUTHCALL` instructions.
 pub mod eip3074;
 
-/// Association of OP codes and correspondent boxed instruction.
+/// Association of instruction opcode and correspondent boxed instruction.
 pub struct BoxedInstructionWithOpCode<'a, H> {
     /// Opcode.
     pub opcode: u8,

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -1,4 +1,14 @@
-//! Implementation of the ConfigureEvmEnv trait.
+//! # AlphaNet EVM configuration
+//!
+//! The [AlphaNetEvmConfig] type implements the [ConfigureEvm] and [ConfigureEvmEnv] traits,
+//! configuring the custom AlphaNet precompiles and instructions.
+//!
+//! These trait implementations allow for custom precompiles and instructions to be implemented and
+//! integrated in a reth node only with importing, without the need to fork the node or EVM
+//! implementation.
+//!
+//! This currently configures the instructions defined by [`alphanet_instructions`], and the
+//! precompiles defined by [`alphanet_precompile`].
 
 use alphanet_instructions::{context::InstructionsContext, eip3074, BoxedInstructionWithOpCode};
 use alphanet_precompile::{bls12_381, secp256r1};

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -1,4 +1,16 @@
 //! Standalone crate for AlphaNet's node configuration and builder types.
+//!
+//! This contains mainly two types, [AlphaNetNode](node::AlphaNetNode) and
+//! [AlphaNetEvmConfig](evm::AlphaNetEvmConfig).
+//!
+//! The [AlphaNetNode](node::AlphaNetNode) type implements the
+//! [NodeTypes](reth::builder::NodeTypes) trait, and configures the engine types required for the
+//! optimism engine API.
+//!
+//! The [AlphaNetEvmConfig](evm::AlphaNetEvmConfig) type implements the
+//! [ConfigureEvm](reth_node_api::ConfigureEvm) and
+//! [ConfigureEvmEnv](reth_node_api::ConfigureEvmEnv) traits, configuring the custom AlphaNet
+//! precompiles and instructions.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(unused_crate_dependencies)]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,4 +1,7 @@
-//! Node types config.
+//! # AlphaNet Node types configuration
+//!
+//! The [AlphaNetNode] type implements the [NodeTypes] trait, and configures the engine types
+//! required for the optimism engine API.
 
 use crate::evm::AlphaNetEvmConfig;
 use reth::builder::NodeTypes;

--- a/crates/precompile/src/bls12_381.rs
+++ b/crates/precompile/src/bls12_381.rs
@@ -1,4 +1,25 @@
-//! EIP-2537 BLS12-381 precompiles.
+//! # EIP-2537 BLS12-381 Precompiles
+//!
+//! This module implements the [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) precompiles for
+//! BLS12-381 curve operations.
+//!
+//! BLS12-381 is a pairing-friendly elliptic curve construction that is used in various
+//! cryptographic constructions. The precompiles implement the following operations:
+//! - G1 point addition, with [`BLS12_G1ADD`](crate::bls12_381::BLS12_G1ADD)
+//! - Multiplication between a G1 point and a scalar, with
+//! [`BLS12_G1MUL`](crate::bls12_381::BLS12_G1MUL)
+//! - Multiexponentiation of G1 points, with
+//! [`BLS12_G1MULTIEXP`](crate::bls12_381::BLS12_G1MULTIEXP)
+//! - G2 point addition, with [`BLS12_G2ADD`](crate::bls12_381::BLS12_G2ADD)
+//! - Multiplication between a G2 point and a scalar, with
+//! [`BLS12_G2MUL`](crate::bls12_381::BLS12_G2MUL)
+//! - Multiexponentiation of G2 points, with
+//! [`BLS12_G2MULTIEXP`](crate::bls12_381::BLS12_G2MULTIEXP)
+//! - The BLS12-381 pairing operation, with [`BLS12_PAIRING`](crate::bls12_381::BLS12_PAIRING)
+//! - Mapping a `F_p` to a G1 point, with
+//! [`BLS12_MAP_FP_TO_G1`](crate::bls12_381::BLS12_MAP_FP_TO_G1)
+//! - Mapping a `F_p^2` element to a G2 point, with
+//! [`BLS12_MAP_FP2_TO_G2`](crate::bls12_381::BLS12_MAP_FP2_TO_G2)
 //!
 //! The precompiles can be inserted in a custom EVM like this:
 //! ```
@@ -146,7 +167,7 @@ pub fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1ADD precompile.
-const BLS12_G1ADD: PrecompileWithAddress =
+pub const BLS12_G1ADD: PrecompileWithAddress =
     PrecompileWithAddress(u64_to_address(BLS12_G1ADD_ADDRESS), Precompile::Standard(g1_add));
 
 /// Encodes a G1 point in affine format into a byte slice with padded elements.
@@ -339,7 +360,7 @@ pub fn g1_add(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1MUL precompile.
-const BLS12_G1MUL: PrecompileWithAddress =
+pub const BLS12_G1MUL: PrecompileWithAddress =
     PrecompileWithAddress(u64_to_address(BLS12_G1MUL_ADDRESS), Precompile::Standard(g1_mul));
 
 /// G1 multiplication call expects `160` bytes as an input that is interpreted as
@@ -387,7 +408,7 @@ pub fn g1_mul(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G1MULTIEXP precompile.
-const BLS12_G1MULTIEXP: PrecompileWithAddress = PrecompileWithAddress(
+pub const BLS12_G1MULTIEXP: PrecompileWithAddress = PrecompileWithAddress(
     u64_to_address(BLS12_G1MULTIEXP_ADDRESS),
     Precompile::Standard(g1_multiexp),
 );
@@ -471,7 +492,7 @@ fn g1_multiexp(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G2ADD precompile.
-const BLS12_G2ADD: PrecompileWithAddress =
+pub const BLS12_G2ADD: PrecompileWithAddress =
     PrecompileWithAddress(u64_to_address(BLS12_G2ADD_ADDRESS), Precompile::Standard(g2_add));
 
 /// G2 addition call expects `512` bytes as an input that is interpreted as byte
@@ -523,7 +544,7 @@ fn g2_add(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G2MUL precompile.
-const BLS12_G2MUL: PrecompileWithAddress =
+pub const BLS12_G2MUL: PrecompileWithAddress =
     PrecompileWithAddress(u64_to_address(BLS12_G2MUL_ADDRESS), Precompile::Standard(g2_mul));
 
 /// G2 multiplication call expects `288` bytes as an input that is interpreted as
@@ -571,7 +592,7 @@ fn g2_mul(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_G2MULTIEXP precompile.
-const BLS12_G2MULTIEXP: PrecompileWithAddress = PrecompileWithAddress(
+pub const BLS12_G2MULTIEXP: PrecompileWithAddress = PrecompileWithAddress(
     u64_to_address(BLS12_G2MULTIEXP_ADDRESS),
     Precompile::Standard(g2_multiexp),
 );
@@ -639,7 +660,7 @@ fn g2_multiexp(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_PAIRING precompile.
-const BLS12_PAIRING: PrecompileWithAddress =
+pub const BLS12_PAIRING: PrecompileWithAddress =
     PrecompileWithAddress(u64_to_address(BLS12_PAIRING_ADDRESS), Precompile::Standard(pairing));
 
 /// Pairing call expects 384*k (k being a positive integer) bytes as an inputs
@@ -714,7 +735,7 @@ fn pairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_MAP_FP_TO_G1 precompile.
-const BLS12_MAP_FP_TO_G1: PrecompileWithAddress = PrecompileWithAddress(
+pub const BLS12_MAP_FP_TO_G1: PrecompileWithAddress = PrecompileWithAddress(
     u64_to_address(BLS12_MAP_FP_TO_G1_ADDRESS),
     Precompile::Standard(map_fp_to_g1),
 );
@@ -766,7 +787,7 @@ fn map_fp_to_g1(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 }
 
 /// [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537#specification) BLS12_MAP_FP2_TO_G2 precompile.
-const BLS12_MAP_FP2_TO_G2: PrecompileWithAddress = PrecompileWithAddress(
+pub const BLS12_MAP_FP2_TO_G2: PrecompileWithAddress = PrecompileWithAddress(
     u64_to_address(BLS12_MAP_FP2_TO_G2_ADDRESS),
     Precompile::Standard(map_fp2_to_g2),
 );

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -1,10 +1,19 @@
 //! # AlphaNet precompiles.
 //!
 //! Implementations of EVM precompiled contracts for AlphaNet.
+//!
+//! Alphanet currently implements the following EIPs, which define precompiles:
+//! - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537): Precompile for BLS12-381 curve
+//! operations. The precompile implementation is located in the [bls12_381] module.
+//! - [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212): Precompile for secp256r1 Curve Support.
+//! The precompile implementation is located in the [secp256r1] module.
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+/// The implementation of [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537): Precompile for BLS12-381 curve.
 pub mod bls12_381;
+
+/// The implementation of [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212): Precompile for secp256r1 Curve Support.
 pub mod secp256r1;
 
 mod addresses;

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -1,4 +1,11 @@
-//! EIP-7212 secp256r1 precompile.
+//! # EIP-7212 secp256r1 Precompile
+//!
+//! This module implements the [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212) precompile for
+//! secp256r1 curve support.
+//!
+//! The main purpose of this precompile is to verify ECDSA signatures that use the secp256r1, or
+//! P256 elliptic curve. The [`P256VERIFY`](crate::secp256r1::P256VERIFY) const represents the
+//! implementation of this precompile, with the address that it is currently deployed at.
 //!
 //! The precompile can be inserted in a custom EVM like this:
 //! ```
@@ -68,7 +75,7 @@ pub fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {
 }
 
 /// [EIP-7212](https://eips.ethereum.org/EIPS/eip-7212#specification) secp256r1 precompile.
-const P256VERIFY: PrecompileWithAddress =
+pub const P256VERIFY: PrecompileWithAddress =
     PrecompileWithAddress(u64_to_address(P256VERIFY_ADDRESS), Precompile::Standard(p256_verify));
 
 /// secp256r1 precompile logic. It takes the input bytes sent to the precompile


### PR DESCRIPTION
This adds more description in the crate level docs, with inter-doc links and links to the EIPs. The `asm-keccak` feature is passed down to reth explicitly, and features are explained in the `src/main.rs` docs.