### PR TITLE
chore: bump reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,19 +133,22 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=7e39c85#7e39c85f9f51e6449a8b661f54df0ac213f18639"
+source = "git+https://github.com/alloy-rs/alloy?rev=6aab216#6aab2164b92c3174cdd81fcb403177361338e594"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "sha2",
+ "alloy-serde",
+ "c-kzg",
+ "serde",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2919acdad13336bc5dc26b636cdd6892c2f27fb0d4a58320a00c2713cf6a4e9a"
+checksum = "872f239c15befa27cc4f0d3d82a70b3365c2d0202562bf906eb93b299fa31882"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -162,20 +165,23 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=7e39c85#7e39c85f9f51e6449a8b661f54df0ac213f18639"
+source = "git+https://github.com/alloy-rs/alloy?rev=6aab216#6aab2164b92c3174cdd81fcb403177361338e594"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "arbitrary",
  "c-kzg",
  "once_cell",
+ "proptest",
+ "proptest-derive",
  "serde",
 ]
 
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=7e39c85#7e39c85f9f51e6449a8b661f54df0ac213f18639"
+source = "git+https://github.com/alloy-rs/alloy?rev=6aab216#6aab2164b92c3174cdd81fcb403177361338e594"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -184,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ed0f2a6c3a1c947b4508522a53a190dba8f94dcd4e3e1a5af945a498e78f2f"
+checksum = "83a35ddfd27576474322a5869e4c123e5f3e7b2177297c18e4e82ea501cb125b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -196,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d34d8de81e23b6d909c094e23b3d357e01ca36b78a8c5424c501eedbe86f0"
+checksum = "99bbad0a6b588ef4aec1b5ddbbfdacd9ef04e00b979617765b03174318ee1f3a"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -244,41 +250,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-engine-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=7e39c85#7e39c85f9f51e6449a8b661f54df0ac213f18639"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
- "alloy-serde",
- "jsonrpsee-types",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "alloy-rpc-trace-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=7e39c85#7e39c85f9f51e6449a8b661f54df0ac213f18639"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types",
- "alloy-serde",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=7e39c85#7e39c85f9f51e6449a8b661f54df0ac213f18639"
+source = "git+https://github.com/alloy-rs/alloy?rev=6aab216#6aab2164b92c3174cdd81fcb403177361338e594"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "alloy-sol-types",
  "arbitrary",
  "itertools 0.12.1",
  "jsonrpsee-types",
@@ -290,9 +272,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-engine"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=6aab216#6aab2164b92c3174cdd81fcb403177361338e594"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "jsonrpsee-types",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=6aab216#6aab2164b92c3174cdd81fcb403177361338e594"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=7e39c85#7e39c85f9f51e6449a8b661f54df0ac213f18639"
+source = "git+https://github.com/alloy-rs/alloy?rev=6aab216#6aab2164b92c3174cdd81fcb403177361338e594"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -301,12 +310,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86ec0a47740b20bc5613b8712d0d321d031c4efc58e9645af96085d5cccfc27"
+checksum = "452d929748ac948a10481fff4123affead32c553cf362841c5103dd508bdfc16"
 dependencies = [
+ "alloy-sol-macro-input",
  "const-hex",
- "dunce",
  "heck 0.4.1",
  "indexmap 2.2.6",
  "proc-macro-error",
@@ -318,19 +327,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-type-parser"
-version = "0.6.4"
+name = "alloy-sol-macro-input"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0045cc89524e1451ccf33e8581355b6027ac7c6e494bb02959d4213ad0d8e91d"
+checksum = "df64e094f6d2099339f9e82b5b38440b159757b6920878f28316243f8166c8d1"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.57",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715f4d09a330cc181fc7c361b5c5c2766408fa59a0bac60349dcb7baabd404cc"
 dependencies = [
  "winnow 0.6.5",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad09ec5853fa700d12d778ad224dcdec636af424d29fad84fb9a2f16a5b0ef09"
+checksum = "43bc2d6dfc2a19fd56644494479510f98b1ee929e04cf0d4aa45e98baa3e545b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -340,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9e1498416f7e7f09af8061970e14936846b6271e153aa5ba539a22a7eb414d"
+checksum = "beb28aa4ecd32fdfa1b1bdd111ff7357dd562c6b2372694cf9e613434fcba659"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -644,10 +668,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "asn1_der"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "async-compression"
@@ -663,15 +699,6 @@ dependencies = [
  "tokio",
  "zstd",
  "zstd-safe",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener",
 ]
 
 [[package]]
@@ -751,6 +778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +800,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -1062,6 +1101,15 @@ checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1425,6 +1473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1635,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1737,6 +1804,26 @@ name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c01c06f5f429efdf2bae21eb67c28b3df3cf85b7dd2d8ef09c0838dac5d33e"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0047d07f2c89b17dd631c80450d69841a6b5d7fb17278cbc43d7e4cfcf2576f3"
+dependencies = [
+ "data-encoding",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "debug-helper"
@@ -1910,8 +1997,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac33cb3f99889a57e56a8c6ccb77aaf0cfc7787602b7af09783f736d77314e1"
+source = "git+https://github.com/sigp/discv5?rev=04ac004#04ac0042a345a9edf93b090007e5d31c008261ed"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm",
@@ -1924,6 +2010,7 @@ dependencies = [
  "hex",
  "hkdf",
  "lazy_static",
+ "libp2p",
  "lru",
  "more-asserts",
  "parking_lot 0.11.2",
@@ -2012,7 +2099,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -2199,12 +2286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,6 +2428,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2480,9 +2562,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-net"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac9e8288ae2c632fa9f8657ac70bfe38a1530f345282d7ba66a1f70b72b7dc4"
+checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2648,7 +2730,17 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -2658,6 +2750,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -2767,10 +2870,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3186,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affdc52f7596ccb2d7645231fc6163bb314630c989b64998f3699a28b4d5d4dc"
+checksum = "c4b0e68d9af1f066c06d6e2397583795b912d78537d7d907c561e82c13d69fa1"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3204,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b005c793122d03217da09af68ba9383363caa950b90d3436106df8cabce935"
+checksum = "92f254f56af1ae84815b9b1325094743dcf05b92abb5e94da2e81a35cff0cada"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3214,25 +3317,25 @@ dependencies = [
  "http",
  "jsonrpsee-core",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
+checksum = "274d68152c24aa78977243bb56f28d7946e6aa309945b37d33174a3f92d89a3a"
 dependencies = [
  "anyhow",
- "async-lock",
  "async-trait",
  "beef",
  "futures-timer",
@@ -3240,22 +3343,23 @@ dependencies = [
  "hyper",
  "jsonrpsee-types",
  "parking_lot 0.12.1",
+ "pin-project",
  "rand 0.8.5",
  "rustc-hash",
  "serde",
  "serde_json",
- "soketto",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
+checksum = "ac13bc1e44cd00448a5ff485824a128629c945f02077804cb659c07a0ba41395"
 dependencies = [
  "async-trait",
  "hyper",
@@ -3273,28 +3377,29 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29110019693a4fa2dbda04876499d098fa16d70eba06b1e6e2b3f1b251419515"
+checksum = "2c326f9e95aeff7d707b2ffde72c22a52acc975ba1c48587776c02b90c4747a6"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c39a00449c9ef3f50b84fc00fc4acba20ef8f559f07902244abf4c15c5ab9c"
+checksum = "3b5bfbda5f8fb63f997102fd18f73e35e34c84c6dcdbdbbe72c6e48f6d2c959b"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "pin-project",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -3309,23 +3414,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
+checksum = "3dc828e537868d6b12bbb07ec20324909a22ced6efca0057c825c3e1126b2c6d"
 dependencies = [
  "anyhow",
  "beef",
  "serde",
  "serde_json",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7cbb3447cf14fd4d2f407c3cc96e6c9634d5440aa1fbed868a31f3c02b27f0"
+checksum = "7cf8dcee48f383e24957e238240f997ec317ba358b4e6d2e8be3f745bcdabdb5"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3334,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.20.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca9cb3933ccae417eb6b08c3448eb1cb46e39834e5b503e395e5e5bd08546c0"
+checksum = "32f00abe918bf34b785f87459b9205790e5361a3f7437adb50e928dc243f27eb"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -3369,7 +3473,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.8",
  "signature",
 ]
 
@@ -3449,6 +3553,122 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libp2p"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681fb3f183edfbedd7a57d32ebe5dcdc0b9f94061185acf3c30249349cc6fc99"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.12",
+ "instant",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "multiaddr",
+ "pin-project",
+ "rw-stream-sink",
+ "thiserror",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107b238b794cb83ab53b74ad5dcf7cca3200899b72fe662840cfb52f5b0a32e6"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "void",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cd50a78ccfada14de94cbacd3ce4b0138157f376870f13d3a8422cd075b4fd"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "void",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.41.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8130a8269e65a2554d55131c770bdf4bcd94d2b8d4efb24ca23699be65066c05"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "rw-stream-sink",
+ "smallvec",
+ "thiserror",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "void",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999ec70441b2fb35355076726a6bc466c932e9bdc66f6a11c6c0aa17c7ab9be0"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "hkdf",
+ "libsecp256k1",
+ "multihash",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92532fc3c4fb292ae30c371815c9b10103718777726ea5497abc268a4761866"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "multistream-select",
+ "once_cell",
+ "rand 0.8.5",
+ "smallvec",
+ "tracing",
+ "void",
+]
+
+[[package]]
 name = "libproc"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,6 +3688,54 @@ dependencies = [
  "bitflags 2.5.0",
  "libc",
  "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+dependencies = [
+ "arrayref",
+ "base64 0.13.1",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -3736,6 +4004,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
+name = "multiaddr"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b852bc02a2da5feed68cd14fa50d0774b92790a5bdbfa932a813926c8472070"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity",
+ "multibase",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.2",
+ "url",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+dependencies = [
+ "core2",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,7 +4286,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -4304,16 +4626,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
@@ -4462,6 +4774,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "quote"
@@ -4728,21 +5049,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -4758,10 +5079,9 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
- "alloy-chains",
  "alloy-rlp",
  "aquamarine",
  "backon",
@@ -4830,8 +5150,8 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
@@ -4849,8 +5169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -4872,8 +5192,8 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "futures",
  "metrics",
@@ -4901,8 +5221,8 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus-core"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "reth-consensus-common",
  "reth-interfaces",
@@ -4911,8 +5231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
@@ -4933,8 +5253,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -4943,8 +5263,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -4954,8 +5274,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "humantime-serde",
  "reth-discv4",
@@ -4968,8 +5288,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "reth-interfaces",
  "reth-primitives",
@@ -4978,8 +5298,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -5009,8 +5329,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "discv5",
@@ -5030,9 +5350,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-discv5"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
+dependencies = [
+ "alloy-rlp",
+ "derive_more",
+ "discv5",
+ "enr",
+ "futures",
+ "itertools 0.12.1",
+ "libp2p-identity",
+ "metrics",
+ "multiaddr",
+ "rand 0.8.5",
+ "reth-metrics",
+ "reth-primitives",
+ "rlp",
+ "secp256k1 0.27.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "reth-dns-discovery"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "data-encoding",
@@ -5054,8 +5398,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -5079,8 +5423,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "aes 0.8.4",
  "alloy-rlp",
@@ -5093,13 +5437,13 @@ dependencies = [
  "educe",
  "futures",
  "generic-array",
- "hmac",
+ "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
  "reth-net-common",
  "reth-primitives",
  "secp256k1 0.27.0",
- "sha2",
+ "sha2 0.10.8",
  "sha3",
  "thiserror",
  "tokio",
@@ -5111,10 +5455,9 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
- "alloy-chains",
  "alloy-rlp",
  "bytes",
  "derive_more",
@@ -5124,6 +5467,7 @@ dependencies = [
  "reth-codecs",
  "reth-discv4",
  "reth-ecies",
+ "reth-eth-wire-types",
  "reth-metrics",
  "reth-primitives",
  "serde",
@@ -5136,9 +5480,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-eth-wire-types"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "derive_more",
+ "reth-codecs",
+ "reth-primitives",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "reth-ethereum-forks"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5153,8 +5511,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-payload-builder",
@@ -5168,8 +5526,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "rayon",
  "reth-db",
@@ -5177,14 +5535,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-evm"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
+dependencies = [
+ "reth-primitives",
+ "revm",
+ "revm-primitives",
+]
+
+[[package]]
+name = "reth-evm-ethereum"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
+dependencies = [
+ "reth-evm",
+ "reth-primitives",
+]
+
+[[package]]
+name = "reth-exex"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
+dependencies = [
+ "reth-config",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "tokio",
+]
+
+[[package]]
 name = "reth-interfaces"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "auto_impl",
  "clap",
  "futures",
- "reth-eth-wire",
+ "reth-eth-wire-types",
  "reth-network-api",
  "reth-primitives",
  "reth-rpc-types",
@@ -5195,8 +5586,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5215,8 +5606,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "bitflags 2.5.0",
  "byteorder",
@@ -5233,8 +5624,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "bindgen",
  "cc",
@@ -5243,8 +5634,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "futures",
  "metrics",
@@ -5255,8 +5646,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics-derive"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -5267,8 +5658,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-common"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "pin-project",
  "reth-primitives",
@@ -5277,8 +5668,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "igd-next",
  "pin-project-lite",
@@ -5291,13 +5682,14 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
  "derive_more",
+ "discv5",
  "enr",
  "fnv",
  "futures",
@@ -5310,6 +5702,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-discv4",
+ "reth-discv5",
  "reth-dns-discovery",
  "reth-ecies",
  "reth-eth-wire",
@@ -5337,10 +5730,9 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
- "alloy-chains",
  "reth-discv4",
  "reth-eth-wire",
  "reth-primitives",
@@ -5352,8 +5744,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5372,21 +5764,22 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
+ "reth-db",
+ "reth-evm",
  "reth-primitives",
+ "reth-provider",
  "reth-rpc-types",
- "revm",
- "revm-primitives",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-node-builder"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "aquamarine",
  "confy",
@@ -5399,6 +5792,7 @@ dependencies = [
  "reth-blockchain-tree",
  "reth-config",
  "reth-db",
+ "reth-exex",
  "reth-interfaces",
  "reth-network",
  "reth-node-api",
@@ -5420,13 +5814,14 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "clap",
  "const-str",
  "derive_more",
  "dirs-next",
+ "discv5",
  "eyre",
  "futures",
  "humantime",
@@ -5481,12 +5876,13 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "eyre",
  "reth-basic-payload-builder",
  "reth-ethereum-payload-builder",
+ "reth-evm-ethereum",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
@@ -5501,12 +5897,18 @@ dependencies = [
 
 [[package]]
 name = "reth-node-optimism"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
+ "async-trait",
  "clap",
  "eyre",
+ "http",
+ "http-body",
+ "hyper",
+ "jsonrpsee",
  "parking_lot 0.12.1",
+ "reqwest",
  "reth-basic-payload-builder",
  "reth-network",
  "reth-node-api",
@@ -5523,12 +5925,14 @@ dependencies = [
  "reth-transaction-pool",
  "revm",
  "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "reth-basic-payload-builder",
@@ -5541,15 +5945,15 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-transaction-pool",
  "revm",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "reth-payload-builder"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "futures-util",
@@ -5563,7 +5967,7 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-transaction-pool",
  "revm-primitives",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5572,8 +5976,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "reth-primitives",
  "reth-rpc-types",
@@ -5582,8 +5986,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5616,7 +6020,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha2",
+ "sha2 0.10.8",
  "strum 0.26.2",
  "tempfile",
  "thiserror",
@@ -5625,8 +6029,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -5638,10 +6042,10 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-db",
+ "reth-evm",
  "reth-interfaces",
  "reth-metrics",
  "reth-nippy-jar",
- "reth-node-api",
  "reth-primitives",
  "reth-trie",
  "revm",
@@ -5653,8 +6057,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "itertools 0.12.1",
  "metrics",
@@ -5673,8 +6077,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "reth-consensus-common",
  "reth-interfaces",
@@ -5688,15 +6092,14 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
  "async-trait",
- "bytes",
  "derive_more",
  "dyn-clone",
  "futures",
@@ -5709,13 +6112,11 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project",
  "rand 0.8.5",
- "reqwest",
  "reth-consensus-common",
+ "reth-evm",
  "reth-interfaces",
  "reth-metrics",
- "reth-network",
  "reth-network-api",
- "reth-node-api",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
@@ -5742,8 +6143,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "jsonrpsee",
  "reth-node-api",
@@ -5754,12 +6155,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "hyper",
  "jsonrpsee",
  "metrics",
+ "pin-project",
  "reth-ipc",
  "reth-metrics",
  "reth-network-api",
@@ -5779,8 +6181,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
@@ -5805,15 +6207,15 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-engine-types",
- "alloy-rpc-trace-types",
  "alloy-rpc-types",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-trace",
  "arbitrary",
  "enr",
  "jsonrpsee-types",
@@ -5829,8 +6231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -5840,8 +6242,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "aquamarine",
  "auto_impl",
@@ -5870,8 +6272,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "clap",
  "parking_lot 0.12.1",
@@ -5888,8 +6290,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "dyn-clone",
  "futures-util",
@@ -5905,8 +6307,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -5914,8 +6316,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "clap",
  "eyre",
@@ -5929,8 +6331,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -5960,10 +6362,9 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
- "alloy-chains",
  "alloy-rlp",
  "auto_impl",
  "derive_more",
@@ -5979,8 +6380,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "0.2.0-beta.4"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=0c363ea#0c363ea010c13fa0250439c7e017997eaf3cbf71"
+version = "0.2.0-beta.5"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=5efe173#5efe17370f017346aaccc1b7514b17023b4220b0"
 dependencies = [
  "alloy-rlp",
  "derive_more",
@@ -6001,9 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "7.2.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fd3ed4b62dc61c647552d8b781811ae25ec74d23309055077e4dfb392444d2"
+checksum = "72a454c1c650b2b2e23f0c461af09e6c31e1d15e1cbebe905a701c46b8a50afc"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -6017,11 +6418,11 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=0ad0338#0ad033820ff216f854ba08515f6f37ac71aa15d8"
+source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=5baa6b3#5baa6b32979e3dc5905528ccd4fe6adaa436925b"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-trace-types",
  "alloy-rpc-types",
+ "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
  "boa_engine",
@@ -6034,9 +6435,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "3.4.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0a1818f8c876b0d71a0714217c34da7df8a42c0462750768779d55680e4554"
+checksum = "d322f2730cd300e99d271a1704a2dfb8973d832428f5aa282aaa40e2473b5eec"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -6044,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "5.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9645a70f1df1e5bd7fa8718b9ba486fac9c3f0467aa6b58e7f590d5f6fd0f7"
+checksum = "931f692f3f4fc72ec39d5d270f8e9d208c4a6008de7590ee96cf948e3b6d3f8d"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -6055,15 +6456,15 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1 0.28.2",
- "sha2",
+ "sha2 0.10.8",
  "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323ad597cf75ac9cb1d161be29fcc3562426f0278a1d04741697fca556e1ceea"
+checksum = "cbbc9640790cebcb731289afb7a7d96d16ad94afeb64b5d0b66443bd151e79d6"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -6086,7 +6487,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -6290,8 +6691,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -6301,7 +6716,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -6316,12 +6744,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -6341,6 +6796,17 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
 ]
 
 [[package]]
@@ -6606,6 +7072,19 @@ name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -6979,9 +7458,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3d0961cd53c23ea94eeec56ba940f636f6394788976e9f16ca5ee0aca7464a"
+checksum = "4497156948bd342b52038035a6fa514a89626e37af9d2c52a5e8d8ebcc7ee479"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7235,7 +7714,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -7286,17 +7776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -7700,6 +8179,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7774,6 +8265,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
@@ -7896,6 +8393,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "widestring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,16 +49,16 @@ alphanet-precompile = { path = "crates/precompile" }
 tokio = { version = "1.21", default-features = false }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "0c363ea", features = ["optimism"] }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "0c363ea" }
-reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "0c363ea" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "0c363ea" }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "5efe173", features = ["optimism"] }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "5efe173" }
+reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "5efe173" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "5efe173" }
 
 # revm
-revm = { version = "7.2.0", features = ["std", "secp256k1"], default-features = false }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "0ad0338" }
-revm-interpreter = { version = "3.4.0", features = ["std"], default-features = false }
-revm-precompile = { version = "5.1.0", features = ["std"], default-features = false }
+revm = { version = "8.0.0", features = ["std", "secp256k1"], default-features = false }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors", rev = "5baa6b3" }
+revm-interpreter = { version = "4.0.0", features = ["std"], default-features = false }
+revm-precompile = { version = "6.0.0", features = ["std"], default-features = false }
 revm-primitives = { version = "3.1.0", features = ["std"], default-features = false }
 
 # misc

--- a/crates/instructions/src/eip3074.rs
+++ b/crates/instructions/src/eip3074.rs
@@ -307,8 +307,8 @@ mod tests {
             B256::ZERO.into(),
         );
 
-        let interpreter = Interpreter::new(Box::new(contract), 3000000, false);
-        assert_eq!(interpreter.gas.spend(), 0);
+        let interpreter = Interpreter::new(contract, 3000000, false);
+        assert_eq!(interpreter.gas.spent(), 0);
 
         interpreter
     }
@@ -393,7 +393,7 @@ mod tests {
 
         // check gas
         let expected_gas = FIXED_FEE_GAS;
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
     }
 
     #[test]
@@ -422,7 +422,7 @@ mod tests {
 
         // check gas
         let expected_gas = FIXED_FEE_GAS + COLD_AUTHORITY_GAS;
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
 
         assert_eq!(context.get(AUTHORIZED_VAR_NAME).unwrap(), authority.to_vec());
     }
@@ -444,7 +444,7 @@ mod tests {
 
         // check gas
         let expected_gas = FIXED_FEE_GAS + COLD_AUTHORITY_GAS + 12; // fixed_fee + cold authority + memory expansion
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
     }
 
     #[test]
@@ -498,7 +498,7 @@ mod tests {
 
         // check gas
         let expected_gas = FIXED_FEE_GAS + WARM_AUTHORITY_GAS;
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
     }
 
     #[test]
@@ -524,7 +524,7 @@ mod tests {
 
         // check gas
         let expected_gas = FIXED_FEE_GAS + COLD_AUTHORITY_GAS;
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
     }
 
     #[test]
@@ -537,7 +537,7 @@ mod tests {
 
         // check gas
         let expected_gas = 0;
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
     }
 
     #[test]
@@ -554,7 +554,7 @@ mod tests {
 
         // check gas
         let expected_gas = 0;
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
     }
 
     #[test]
@@ -576,7 +576,7 @@ mod tests {
 
         // check gas
         let expected_gas = 66612;
-        assert_eq!(expected_gas, interpreter.gas.spend());
+        assert_eq!(expected_gas, interpreter.gas.spent());
 
         // check next action
         let value = U256::from(value);


### PR DESCRIPTION
bump reth to main

this includes a few breaking changes in the evm config trait

also reuse OPevmconfig to delegate calls

this now supports alphabet evm in rpc