### PR TITLE
chore: remove revm dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,6 @@ dependencies = [
  "p256",
  "reth",
  "reth-node-api",
- "revm",
  "rstest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,6 @@ reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "7
 reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "76b32c8" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "76b32c8" }
 
-# revm
-revm = { version = "9", features = ["std", "secp256k1", "blst"], default-features = false }
-
 # misc
 clap = "4"
 eyre = "0.6.12"

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -11,7 +11,6 @@ categories.workspace = true
 
 [dependencies]
 reth.workspace = true
-revm.workspace = true
 
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 
@@ -23,7 +22,6 @@ rstest.workspace = true
 [features]
 optimism = [
   "reth/optimism",
-  "revm/optimism"
 ]
 
 [lints]

--- a/crates/precompile/src/bls12_381.rs
+++ b/crates/precompile/src/bls12_381.rs
@@ -1,14 +1,15 @@
 //! # EIP-2537 BLS12-381 Precompiles imported from Revm.
 
-use revm::precompile::bls12_381::{
-    g1_add::PRECOMPILE as BLS12_G1ADD, g1_msm::PRECOMPILE as BLS12_G1MSM,
-    g1_mul::PRECOMPILE as BLS12_G1MUL, g2_add::PRECOMPILE as BLS12_G2ADD,
-    g2_msm::PRECOMPILE as BLS12_G2MSM, g2_mul::PRECOMPILE as BLS12_G2MUL,
-    map_fp2_to_g2::PRECOMPILE as BLS12_MAP_FP2_TO_G2,
-    map_fp_to_g1::PRECOMPILE as BLS12_MAP_FP_TO_G1, pairing::PRECOMPILE as BLS12_PAIRING,
+use reth::revm::precompile::{
+    bls12_381::{
+        g1_add::PRECOMPILE as BLS12_G1ADD, g1_msm::PRECOMPILE as BLS12_G1MSM,
+        g1_mul::PRECOMPILE as BLS12_G1MUL, g2_add::PRECOMPILE as BLS12_G2ADD,
+        g2_msm::PRECOMPILE as BLS12_G2MSM, g2_mul::PRECOMPILE as BLS12_G2MUL,
+        map_fp2_to_g2::PRECOMPILE as BLS12_MAP_FP2_TO_G2,
+        map_fp_to_g1::PRECOMPILE as BLS12_MAP_FP_TO_G1, pairing::PRECOMPILE as BLS12_PAIRING,
+    },
+    PrecompileWithAddress,
 };
-
-use reth::revm::precompile::PrecompileWithAddress;
 
 /// Returns the bls12381 precompiles with their addresses.
 pub fn precompiles() -> impl Iterator<Item = PrecompileWithAddress> {

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -15,10 +15,10 @@
 //!     revm::{
 //!         precompile::{PrecompileSpecId, Precompiles},
 //!         primitives::{Address, Bytes, CfgEnvWithHandlerCfg, TxEnv},
+//!         Database, Evm, EvmBuilder,
 //!     },
 //! };
 //! use reth_node_api::{ConfigureEvm, ConfigureEvmEnv};
-//! use revm::{Database, Evm, EvmBuilder};
 //! use std::sync::Arc;
 //!
 //! #[derive(Debug, Clone, Copy, Default)]


### PR DESCRIPTION
Now that revm from reth is imported with `blst` feature we can use it instead of adding a separate dependency. 