### PR TITLE
chore: bump alloy, reth, revm, and eip3074-instructions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.76" # MSRV
+          toolchain: "1.79" # MSRV
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "eip3074-instructions"
 version = "0.1.0"
-source = "git+https://github.com/emostov/eip3074-instructions.git?rev=0f8c5f3#0f8c5f30bf1626153e4994d1b38d62dfa17a1acc"
+source = "git+https://github.com/emostov/eip3074-instructions.git?branch=bump-revm#bb8035a7dfdf2891f279e185d039eea6212cd5f9"
 dependencies = [
  "revm",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,15 +79,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
@@ -118,28 +109,28 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45855eb65e9cc70294ebea1279f6d8ee0636bf2ed3897683ebbae2739975ae8c"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-eips",
+ "alloy-genesis",
  "alloy-provider",
  "alloy-rpc-client",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-serde",
  "alloy-signer",
  "alloy-transport",
  "alloy-transport-http",
- "reqwest",
 ]
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2feb5f466b3a786d5a622d8926418bc6a0d38bf632909f6ee9298a4a1d8c6e0"
+checksum = "1752d7d62e2665da650a36d84abbf239f812534475d51f072a49a533513b7cdd"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -151,47 +142,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58047cc851e58c26224521d1ecda466e3d746ebca0274cd5427aa660a88c353"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-serde",
  "arbitrary",
  "c-kzg",
- "proptest",
- "proptest-derive",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
-dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "arbitrary",
- "c-kzg",
- "proptest",
- "proptest-derive",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5d42d9f87896536234b0fac1a84ad9d9dc7a4b27839cac35d0899e64ddf083"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
  "futures",
@@ -201,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af3faff14c12c8b11037e0a093dd157c3702becb8435577a2408534d0758315"
+checksum = "529fc6310dc1126c8de51c376cbc59c79c7f662bd742be7dc67055d5421a81b4"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -213,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6e6436a9530f25010d13653e206fab4c9feddacf21a54de8d7311b275bc56b"
+checksum = "413902aa18a97569e60f679c23f46a18db1656d87ab4d4e49d0e1e52042f66df"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -231,67 +206,38 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a3e14fa0d152d00bd8daf605eb74ad397efb0f54bd7155585823dddb4401e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-serde",
  "arbitrary",
  "c-kzg",
  "derive_more",
+ "k256",
  "once_cell",
- "proptest",
- "proptest-derive",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "arbitrary",
- "c-kzg",
- "derive_more",
- "once_cell",
- "proptest",
- "proptest-derive",
  "serde",
  "sha2 0.10.8",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cb76c8a3913f2466c5488f3a915e3a15d15596bdc935558c1a9be75e9ec508"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-serde",
  "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-genesis"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaeaccd50238126e3a0ff9387c7c568837726ad4f4e399b528ca88104d6c25ef"
+checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -301,8 +247,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a9feec2352c78545d1a37415699817bae8dc41654bd1bfe57d6cdd5433bd"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -313,14 +260,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3223d71dc78f464b2743418d0be8b5c894313e272105a6206ad5e867d67b3ce2"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -331,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f783611babedbbe90db3478c120fb5f5daacceffc210b39adc0af4fe0da70bad"
+checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -349,7 +298,7 @@ dependencies = [
  "k256",
  "keccak-asm",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.4.0",
  "rand 0.8.5",
  "ruint",
  "serde",
@@ -358,20 +307,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29da7457d853cb8199ec04b227d5d2ef598be3e59fc2bbad70c8be213292f32"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
+ "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-rpc-types-eth",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -389,10 +340,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rlp"
-version = "0.3.5"
+name = "alloy-pubsub"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b155716bab55763c95ba212806cf43d05bcc70e5f35b02bad20cf5ec7fe11fed"
+checksum = "f64acfec654ade392cecfa9bba0408eb2a337d55f1b857925da79970cb70f3d6"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "bimap",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a43b18702501396fa9bcdeecd533bc85fac75150d308fc0f6800a01e6234a003"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -401,23 +371,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8037e03c7f462a063f28daec9fda285a9a89da003c552f8637a80b9c8fd96241"
+checksum = "d83524c1f6162fcb5b0decf775498a125066c86dda6066ed609531b0e912f85a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a9e609524fa31c2c70eb24c0da60796809193ad4787a6dfe6d0db0d3ac112d"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "futures",
  "pin-project",
  "reqwest",
@@ -432,83 +406,49 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5d76f1e8b22f48b7b8f985782b68e7eb3938780e50e8b646a53e41a598cdf5"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-sol-types",
- "itertools 0.12.1",
- "jsonrpsee-types",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
+ "alloy-serde",
  "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
-name = "alloy-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+name = "alloy-rpc-types-admin"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "137f0014c3a61ccc5168289fcc214d7296c389c0bf60425c0f898cff1d7e4bec"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-genesis",
  "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-sol-types",
- "itertools 0.12.1",
- "jsonrpsee-types",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4282c002a4ae9f57887dae57083fcca6dca09cb6685bf98b8582ea93cb3df97d"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-anvil"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b47dcc8e3bebea57b1c9495a7e6f3313e99d355c0f5b80473cfbdfcbdd6ebea"
 dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "serde",
- "serde_with",
- "thiserror",
-]
-
-[[package]]
-name = "alloy-rpc-types-beacon"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
-dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-primitives",
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-rpc-types-engine",
  "serde",
  "serde_with",
  "thiserror",
@@ -516,88 +456,98 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73445fbc5c02258e3d0d977835c92366a4d91545fd456c3fc8601c61810bc9f6"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "jsonrpsee-types",
- "jsonwebtoken 9.3.0",
+ "jsonwebtoken",
  "rand 0.8.5",
  "serde",
  "thiserror",
 ]
 
 [[package]]
-name = "alloy-rpc-types-engine"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+name = "alloy-rpc-types-eth"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605fa8462732bb8fd0645a9941e12961e079d45ae6a44634c826f8229c187bdf"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.13.0",
  "jsonrpsee-types",
- "jsonwebtoken 9.3.0",
- "rand 0.8.5",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
 [[package]]
-name = "alloy-rpc-types-trace"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+name = "alloy-rpc-types-mev"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffcb83a5a91d327c40ba2157a19016bb883c1426f1708fea5f9e042032fd73e"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f561a8cdd377b6ac3beab805b9df5ec2c7d99bb6139aab23c317f26df6fb346"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types-txpool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06a4bd39910631c11148c5b2c55e2c61f8626affd2a612e382c668d5e5971ce"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c5b9057acc02aee1b8aac2b5a0729cb0f73d080082c111313e5d1f92a96630"
 dependencies = [
  "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=bd39117#bd391179fb4ebf64fe13484e44f2e432baf9b6c2"
-dependencies = [
- "alloy-primitives",
+ "arbitrary",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-signer"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f10592696f4ab8b687d5a8ab55e998a14ea0ca5f8eb20ad74a96ad671bb54a"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -608,11 +558,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-signer-wallet"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+name = "alloy-signer-local"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b537f3e55f30753578f4623d5f66ddad8fa582af3fa6b15bad23dd1b9775228"
 dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -626,23 +577,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bad41a7c19498e3f6079f7744656328699f8ea3e783bdd10d85788cd439f572"
+checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9899da7d011b4fe4c406a524ed3e3f963797dbc93b45479d60341d3a27b252"
+checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -652,16 +603,16 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32d595768fdc61331a132b6f65db41afae41b9b97d36c21eb1b955c422a7e60"
+checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -670,24 +621,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.66",
+ "syn 2.0.71",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa2fbd22d353d8685bd9fee11ba2d8b5c3b1d11e56adb3265fcf1f32bfdf404"
+checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
 dependencies = [
+ "serde",
  "winnow 0.6.13",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49042c6d3b66a9fe6b2b5a8bf0d39fc2ae1ee0310a2a26ffedd79fb097878dd"
+checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -698,8 +650,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b0f6f4a2593b258fa7b6cae8968e6a4c404d9ef4f5bc74401f2d04fa23fa"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -710,14 +663,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
+ "tracing",
  "url",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=5796024#57960245a0e17ec3ba6c0d996d47279ee674088a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8f1eefa8cb9e7550740ee330feba4fed303a77ad3085707546f9152a88c380"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -729,6 +683,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-transport-ws"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ccc1c8f8ae415e93ec0e7851bd4cdf4afdd48793d13a91b860317da1f36104"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http 1.1.0",
+ "rustls",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "ws_stream_wasm",
+]
+
+[[package]]
 name = "alloy-trie"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,13 +708,9 @@ checksum = "03704f265cbbb943b117ecb5055fd46e8f41e7dc8a58b1aed20bcd40ace38c15"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
- "derive_arbitrary",
  "derive_more",
  "hashbrown 0.14.5",
  "nybbles",
- "proptest",
- "proptest-derive",
  "serde",
  "smallvec",
  "tracing",
@@ -754,8 +722,9 @@ version = "0.0.0"
 dependencies = [
  "alphanet-node",
  "clap",
- "reth 0.2.0-beta.8",
- "reth-node-optimism 0.2.0-beta.8",
+ "reth",
+ "reth-cli-util",
+ "reth-node-optimism",
  "tikv-jemallocator",
  "tracing",
 ]
@@ -767,9 +736,10 @@ dependencies = [
  "alphanet-precompile",
  "eip3074-instructions",
  "eyre",
- "reth 0.2.0-beta.8",
- "reth-node-api 0.2.0-beta.8",
- "reth-node-optimism 0.2.0-beta.8",
+ "reth",
+ "reth-chainspec",
+ "reth-node-api",
+ "reth-node-optimism",
 ]
 
 [[package]]
@@ -778,8 +748,9 @@ version = "0.0.0"
 dependencies = [
  "eyre",
  "p256",
- "reth 0.2.0-beta.8",
- "reth-node-api 0.2.0-beta.8",
+ "reth",
+ "reth-chainspec",
+ "reth-node-api",
  "rstest",
 ]
 
@@ -789,13 +760,15 @@ version = "0.0.0"
 dependencies = [
  "alloy",
  "alloy-network",
- "alloy-signer-wallet",
+ "alloy-signer-local",
  "alphanet-node",
  "once_cell",
- "reth 0.2.0-beta.8",
- "reth-node-core 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
+ "reth",
+ "reth-chainspec",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-primitives",
+ "reth-tracing",
  "tokio",
  "url",
 ]
@@ -881,7 +854,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1036,18 +1009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,24 +1043,29 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -1107,17 +1073,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "attohttpc"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
-dependencies = [
- "http 0.2.12",
- "log",
- "url",
-]
 
 [[package]]
 name = "aurora-engine-modexp"
@@ -1137,7 +1092,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1225,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,7 +1200,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1248,9 +1209,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1282,9 +1243,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "arbitrary",
  "serde",
@@ -1292,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "bitm"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b9ea263f0faf826a1c9de0e8bf8f32f5986c05f5e3abcf6bcde74616009586"
+checksum = "b06e8e5bec3490b9f6f3adbb78aa4f53e8396fd9994e8a62a346b44ea7c15f35"
 dependencies = [
  "dyn_size_of",
 ]
@@ -1340,16 +1301,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.1"
+name = "bls12_381"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1366,32 +1327,33 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6fb81ca0f301f33aff7401e2ffab37dc9e0e4a1cf0ccf6b34f4d9e60aa0682"
+checksum = "b49637e7ecb7c541c46c3e885d4c49326ad8076dbfb88bef2cf3165d8ea7df2b"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "boa_interner",
  "boa_macros",
  "indexmap 2.2.6",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.0.0",
 ]
 
 [[package]]
 name = "boa_engine"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600e4e4a65b26efcef08a7b1cf2899d3845a32e82e067ee3b75eaf7e413ff31c"
+checksum = "411558b4cbc7d0303012e26721815e612fed78179313888fd5dd8d6c50d70099"
 dependencies = [
  "arrayvec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
  "boa_macros",
  "boa_parser",
  "boa_profiler",
+ "boa_string",
  "bytemuck",
  "cfg-if",
  "dashmap",
@@ -1400,18 +1362,17 @@ dependencies = [
  "icu_normalizer",
  "indexmap 2.2.6",
  "intrusive-collections",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "num-bigint",
  "num-integer",
  "num-traits",
  "num_enum",
  "once_cell",
- "paste",
  "pollster",
  "portable-atomic",
  "rand 0.8.5",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "ryu-js",
  "serde",
  "serde_json",
@@ -1425,21 +1386,22 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c055ef3cd87ea7db014779195bc90c6adfc35de4902e3b2fe587adecbd384578"
+checksum = "8eff345a85a39cf9b8ed863198947d61e6df2b1d774002b57341158b0ce2c525"
 dependencies = [
  "boa_macros",
  "boa_profiler",
+ "boa_string",
  "hashbrown 0.14.5",
  "thin-vec",
 ]
 
 [[package]]
 name = "boa_interner"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cacc9caf022d92195c827a3e5bf83f96089d4bfaff834b359ac7b6be46e9187"
+checksum = "72b779280420804c70da9043d152c84eb96e2f7c9e7d1ec3262decf59f9349df"
 dependencies = [
  "boa_gc",
  "boa_macros",
@@ -1447,29 +1409,29 @@ dependencies = [
  "indexmap 2.2.6",
  "once_cell",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "boa_macros"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be9c93793b60dac381af475b98634d4b451e28336e72218cad9a20176218dbc"
+checksum = "25e0097fa69cde4c95f9869654004340fbbe2bcf3ce9189ba2a31a65ac40e0a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
  "synstructure",
 ]
 
 [[package]]
 name = "boa_parser"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8592556849f0619ed142ce2b3a19086769314a8d657f93a5765d06dbce4818"
+checksum = "dd63fe8faf62561fc8c50f9402687e8cfde720b57d292fb3b4ac17c821878ac1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -1479,14 +1441,27 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.0.0",
 ]
 
 [[package]]
 name = "boa_profiler"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d8372f2d5cbac600a260de87877141b42da1e18d2c7a08ccb493a49cbd55c0"
+checksum = "cd9da895f0df9e2a97b36c1f98e0c5d2ab963abc8679d80f2a66f7bcb211ce90"
+
+[[package]]
+name = "boa_string"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9ca6668df83fcd3c2903f6f296b7180421908c5b478ebe0d1c468be9fd60e1c"
+dependencies = [
+ "fast-float",
+ "paste",
+ "rustc-hash 2.0.0",
+ "sptr",
+ "static_assertions",
+]
 
 [[package]]
 name = "boyer-moore-magiclen"
@@ -1553,9 +1528,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1568,7 +1543,7 @@ checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1579,9 +1554,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 dependencies = [
  "serde",
 ]
@@ -1640,23 +1615,28 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1685,7 +1665,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1720,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1730,26 +1710,26 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1760,9 +1740,9 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "coins-bip32"
-version = "0.8.7"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
+checksum = "66c43ff7fd9ff522219058808a259e61423335767b1071d5b346de60d9219657"
 dependencies = [
  "bs58",
  "coins-core",
@@ -1776,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "coins-bip39"
-version = "0.8.7"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
+checksum = "4c4587c0b4064da887ed39a6522f577267d57e58bdd583178cd877d721b56a2e"
 dependencies = [
  "bitvec",
  "coins-bip32",
@@ -1792,19 +1772,18 @@ dependencies = [
 
 [[package]]
 name = "coins-core"
-version = "0.8.7"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
+checksum = "6b3aeeec621f4daec552e9d28befd58020a78cfc364827d06a753e8bc13c6c4b"
 dependencies = [
  "base64 0.21.7",
  "bech32",
  "bs58",
+ "const-hex",
  "digest 0.10.7",
  "generic-array",
- "hex",
  "ripemd",
  "serde",
- "serde_derive",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -1815,6 +1794,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -1848,15 +1837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d72c1252426a83be2092dd5884a5f6e3b8e7180f6891b6263d2c21b92ec8816"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1903,10 +1883,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-str"
-version = "0.5.7"
+name = "const_format"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "convert_case"
@@ -2021,7 +2016,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -2121,16 +2116,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version 0.4.0",
  "subtle",
  "zeroize",
@@ -2144,77 +2138,42 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.10.2",
- "darling_macro 0.10.2",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
-dependencies = [
- "darling_core 0.20.9",
- "darling_macro 0.20.9",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.9.3",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.66",
+ "strsim",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.10.2",
+ "darling_core",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
-dependencies = [
- "darling_core 0.20.9",
- "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2312,32 +2271,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
-dependencies = [
- "darling 0.10.2",
- "derive_builder_core",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
-dependencies = [
- "darling 0.10.2",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2350,7 +2284,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2458,26 +2392,20 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
-name = "dns-lookup"
-version = "1.0.8"
+name = "doctest-file"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
-dependencies = [
- "cfg-if",
- "libc",
- "socket2 0.4.10",
- "winapi",
-]
+checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "dunce"
@@ -2537,30 +2465,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "eip3074-instructions"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/eip3074-instructions.git?rev=a9022e4#a9022e4b9d440c1f8ba4d73af1eff0e91b7dd8ab"
+source = "git+https://github.com/emostov/eip3074-instructions.git?rev=0f8c5f3#0f8c5f30bf1626153e4994d1b38d62dfa17a1acc"
 dependencies = [
- "reth 0.2.0-beta.7",
+ "revm",
 ]
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -2596,9 +2512,9 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enr"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab656b89cdd15051d92d0931888103508de14ef9e51177c86d478dfa551ce0f"
+checksum = "972070166c68827e64bd1ebc8159dd8e32d9bc2da7ebe8f20b61308f7974ad30"
 dependencies = [
  "alloy-rlp",
  "base64 0.21.7",
@@ -2608,22 +2524,10 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.5",
- "secp256k1 0.28.2",
+ "secp256k1",
  "serde",
  "sha3",
  "zeroize",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2635,20 +2539,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "3.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2659,7 +2550,7 @@ checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2717,27 +2608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2656,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2905,16 +2776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,7 +2783,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2938,30 +2799,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
-name = "futures-test"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce388237b32ac42eca0df1ba55ed3bbda4eaf005d7d4b5dbc0b20ab962928ac9"
-dependencies = [
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "futures-util",
- "pin-project",
- "pin-utils",
-]
-
-[[package]]
 name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers",
- "send_wrapper",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -3104,16 +2948,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -3132,9 +2976,6 @@ name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3273,20 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -3301,21 +3131,21 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-range-header"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -3347,40 +3177,18 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.1.0",
+ "http-body",
  "httparse",
  "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.7",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "httparse",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3390,49 +3198,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.29",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper",
  "hyper-util",
- "rustls 0.22.4",
+ "log",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-system-resolver"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea26c5d0b6ab9d72219f65000af310f042a740926f7b2fa3553e774036e2e7"
-dependencies = [
- "derive_builder",
- "dns-lookup",
- "hyper 0.14.29",
- "tokio",
- "tower-service",
- "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3443,7 +3224,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3453,16 +3234,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.3.1",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -3496,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137d96353afc8544d437e8a99eceb10ab291352699573b0de5b08bda38c78c60"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3508,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0aa2536adc14c07e2a521e95512b75ed8ef832f0fdf9299d4a0a45d2be2a9d"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3521,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c17d8f6524fdca4471101dd71f0a132eb6382b5d6d7f2970441cb25f6f435a"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -3535,15 +3316,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c6c3e8bf9580e2dafee8de6f9ec14826aaf359787789c7724f1f85f47d3dc"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
 
 [[package]]
 name = "icu_normalizer"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accb85c5b2e76f8dade22978b3795ae1e550198c6cfc7e915144e17cd6e2ab56"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -3559,15 +3340,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3744fecc0df9ce19999cdaf1f9f3a48c253431ce1d67ef499128fe9d0b607ab"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
 name = "icu_properties"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8173ba888885d250016e957b8ebfd5a65cdb690123d8833a19f6833f9c2b579"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -3580,15 +3361,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70a8b51ee5dd4ff8f20ee9b1dd1bc07afc110886a3747b1fec04cc6e5a15815"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_provider"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba58e782287eb6950247abbf11719f83f5d4e4a5c1f2cd490d30a334bc47c2f4"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
 dependencies = [
  "displaydoc",
  "icu_locid",
@@ -3603,13 +3384,13 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3617,17 +3398,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -3641,33 +3411,12 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "igd-next"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
-dependencies = [
- "async-trait",
- "attohttpc",
- "bytes",
- "futures",
- "http 0.2.12",
- "hyper 0.14.29",
- "log",
- "rand 0.8.5",
- "tokio",
- "url",
- "xmltree",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3710,18 +3459,18 @@ dependencies = [
 
 [[package]]
 name = "include_dir"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
 dependencies = [
  "include_dir_macros",
 ]
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3776,30 +3525,18 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "1.2.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
+checksum = "67bafc2f5dbdad79a6d925649758d5472647b416028099f0b829d1b67fdd47d3"
 dependencies = [
- "blocking",
- "cfg-if",
+ "doctest-file",
  "futures-core",
- "futures-io",
- "intmap",
  "libc",
- "once_cell",
- "rustc_version 0.4.0",
- "spinning",
- "thiserror",
- "to_method",
+ "recvmsg",
  "tokio",
- "winapi",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "intmap"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "intrusive-collections"
@@ -3863,10 +3600,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -3888,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
+checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3906,45 +3672,49 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
+checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
 dependencies = [
+ "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 0.2.12",
+ "http 1.1.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls-native-certs 0.7.0",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
+checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
 dependencies = [
  "anyhow",
  "async-trait",
  "beef",
+ "bytes",
  "futures-timer",
  "futures-util",
- "hyper 0.14.29",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -3956,15 +3726,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
+checksum = "2d90064e04fb9d7282b1c71044ea94d0bbc6eff5621c66f1a0bce9e9de7cf3ac"
 dependencies = [
  "async-trait",
- "hyper 0.14.29",
- "hyper-rustls 0.24.2",
+ "base64 0.22.1",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "rustls",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror",
@@ -3976,26 +3751,30 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0bb047e79a143b32ea03974a6bf59b62c2a4c5f5d42a381c907a8bbb3f75c0"
+checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
+checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
 dependencies = [
+ "anyhow",
  "futures-util",
- "http 0.2.12",
- "hyper 0.14.29",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "pin-project",
@@ -4013,12 +3792,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
 dependencies = [
- "anyhow",
  "beef",
+ "http 1.1.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -4026,9 +3805,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448d8eacd945cc17b6c0b42c361531ca36a962ee186342a97cdb8fca679cd77"
+checksum = "4727ac037f834c6f04c0912cada7532dbddb54e92fbc64e33d6cb8c24af313c9"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -4037,29 +3816,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
+checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
 dependencies = [
- "http 0.2.12",
+ "http 1.1.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "url",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -4070,8 +3835,8 @@ checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
- "pem 3.0.4",
- "ring 0.17.8",
+ "pem",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -4111,12 +3876,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "konst"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
 dependencies = [
- "spin 0.5.2",
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "kzg-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9920cd4460ce3cbca19c62f3bb9a9611562478a4dc9d2c556f4a7d049c5b6b"
+dependencies = [
+ "bls12_381",
+ "glob",
+ "hex",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -4132,32 +3927,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libffi"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
-dependencies = [
- "libc",
- "libffi-sys",
-]
-
-[[package]]
-name = "libffi-sys"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4215,15 +3991,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.41.2"
+version = "0.41.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8130a8269e65a2554d55131c770bdf4bcd94d2b8d4efb24ca23699be65066c05"
+checksum = "a5a8920cbd8540059a01950c1e5c96ea8d89eb50c51cd366fc18bdf540a6e48f"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
- "instant",
  "libp2p-identity",
  "multiaddr",
  "multihash",
@@ -4239,6 +4014,7 @@ dependencies = [
  "tracing",
  "unsigned-varint 0.8.0",
  "void",
+ "web-time",
 ]
 
 [[package]]
@@ -4300,7 +4076,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -4391,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
@@ -4444,12 +4220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4457,9 +4227,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
@@ -4475,20 +4245,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
-dependencies = [
- "ahash",
- "metrics-macros",
- "portable-atomic",
-]
-
-[[package]]
-name = "metrics"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -4496,111 +4255,48 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.12.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
-dependencies = [
- "base64 0.21.7",
- "hyper 0.14.29",
- "indexmap 1.9.3",
- "ipnet",
- "metrics 0.21.1",
- "metrics-util 0.15.0",
- "quanta 0.11.1",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d58e362dc7206e9456ddbcdbd53c71ba441020e62104703075a69151e38d85f"
+checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.2.6",
- "metrics 0.22.3",
- "metrics-util 0.16.3",
- "quanta 0.12.3",
+ "metrics",
+ "metrics-util",
+ "quanta",
  "thiserror",
 ]
 
 [[package]]
-name = "metrics-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "metrics-process"
-version = "1.0.14"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2a67e2580fbeba4d5a96e659945981e700a383b4cea1432e0cfc18f58c5da"
+checksum = "cb524e5438255eaa8aa74214d5a62713b77b2c3c6e3c0bbeee65cfd9a58948ba"
 dependencies = [
  "libproc",
  "mach2",
- "metrics 0.21.1",
+ "metrics",
  "once_cell",
  "procfs",
  "rlimit",
- "windows 0.52.0",
-]
-
-[[package]]
-name = "metrics-process"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d8f5027620bf43b86e2c8144beea1e4323aec39241f5eae59dee54f79c6a29"
-dependencies = [
- "libproc",
- "mach2",
- "metrics 0.22.3",
- "once_cell",
- "procfs",
- "rlimit",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
 dependencies = [
- "aho-corasick 0.7.20",
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.13.2",
- "indexmap 1.9.3",
- "metrics 0.21.1",
- "num_cpus",
- "ordered-float 3.9.2",
- "quanta 0.11.1",
- "radix_trie",
- "sketches-ddsketch",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
-dependencies = [
- "aho-corasick 1.1.3",
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
- "metrics 0.22.3",
+ "metrics",
  "num_cpus",
- "ordered-float 4.2.0",
- "quanta 0.12.3",
+ "ordered-float",
+ "quanta",
  "radix_trie",
  "sketches-ddsketch",
 ]
@@ -4613,9 +4309,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -4629,9 +4325,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -4800,9 +4496,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4893,7 +4589,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4912,7 +4608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f06be0417d97f81fe4e5c86d7d01b392655a9cac9c19a848aa033e18937b23"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "const-hex",
  "proptest",
  "serde",
@@ -4921,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -4933,6 +4628,35 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d10e10cbbdb3931fed5109bbd570c0a6cf0ce08db1f93401cfb5cefc51998d1"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9978c3d449abb03526d378988ae6d51b049ef36205cc97bf284574df9f578021"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "op-alloy-consensus",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -4946,7 +4670,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4963,7 +4687,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4992,18 +4716,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "3.9.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
 dependencies = [
  "num-traits",
 ]
@@ -5037,6 +4752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5062,12 +4786,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -5112,9 +4830,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5131,15 +4849,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
-]
-
-[[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
 ]
 
 [[package]]
@@ -5169,9 +4878,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5189,6 +4898,16 @@ dependencies = [
  "dyn_size_of",
  "rayon",
  "wyhash",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -5221,7 +4940,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5250,7 +4969,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5264,17 +4983,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs8"
@@ -5291,12 +4999,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "pollster"
@@ -5391,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -5404,7 +5106,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "chrono",
  "flate2",
  "hex",
@@ -5419,20 +5121,20 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "chrono",
  "hex",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -5442,6 +5144,16 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-arbitrary-interop"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
+dependencies = [
+ "arbitrary",
+ "proptest",
 ]
 
 [[package]]
@@ -5456,40 +5168,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "public-ip"
-version = "0.2.2"
+name = "proptest-derive"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4c40db5262d93298c363a299f8bc1b3a956a78eecddba3bc0e58b76e2f419a"
+checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
- "dns-lookup",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.29",
- "hyper-system-resolver",
- "pin-project-lite",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "trust-dns-client",
- "trust-dns-proto 0.20.4",
-]
-
-[[package]]
-name = "quanta"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach2",
- "once_cell",
- "raw-cpuid 10.7.0",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -5501,7 +5187,7 @@ dependencies = [
  "crossbeam-utils",
  "libc",
  "once_cell",
- "raw-cpuid 11.0.2",
+ "raw-cpuid",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
@@ -5520,6 +5206,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 1.1.0",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash 1.1.0",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5629,19 +5362,20 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "stability",
  "strum",
+ "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -5649,20 +5383,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.7.0"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
 dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
-dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -5686,6 +5411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,11 +5427,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -5720,7 +5451,7 @@ version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
- "aho-corasick 1.1.3",
+ "aho-corasick",
  "memchr",
  "regex-automata 0.4.7",
  "regex-syntax 0.8.4",
@@ -5741,7 +5472,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
- "aho-corasick 1.1.3",
+ "aho-corasick",
  "memchr",
  "regex-syntax 0.8.4",
 ]
@@ -5760,9 +5491,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "regress"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eae2a1ebfecc58aff952ef8ccd364329abe627762f5bf09ff42eb9d98522479"
+checksum = "16fe0a24af5daaae947294213d2fd2646fbf5e1fbacc1d4ba3e84b2393854842"
 dependencies = [
  "hashbrown 0.14.5",
  "memchr",
@@ -5776,19 +5507,19 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body",
  "http-body-util",
- "hyper 1.3.1",
- "hyper-rustls 0.26.0",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -5799,9 +5530,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.0",
- "rustls-pemfile 2.1.2",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5809,12 +5541,13 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg 0.52.0",
 ]
 
@@ -5830,155 +5563,75 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "ahash",
  "alloy-rlp",
  "aquamarine",
  "backon",
- "boyer-moore-magiclen",
  "clap",
- "comfy-table",
  "confy",
- "crossterm",
  "discv5",
  "eyre",
  "fdlimit",
  "futures",
- "human_bytes",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "libc",
- "metrics-process 1.0.14",
- "proptest",
- "rand 0.8.5",
- "ratatui",
- "rayon",
- "reth-basic-payload-builder 0.2.0-beta.7",
- "reth-beacon-consensus 0.2.0-beta.7",
- "reth-blockchain-tree 0.2.0-beta.7",
- "reth-cli-runner 0.2.0-beta.7",
- "reth-config 0.2.0-beta.7",
- "reth-consensus 0.2.0-beta.7",
- "reth-consensus-common 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-db-common 0.2.0-beta.7",
- "reth-discv4 0.2.0-beta.7",
- "reth-discv5 0.2.0-beta.7",
- "reth-downloaders 0.2.0-beta.7",
- "reth-ethereum-payload-builder 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-exex 0.2.0-beta.7",
- "reth-fs-util 0.2.0-beta.7",
- "reth-interfaces",
- "reth-network 0.2.0-beta.7",
- "reth-network-api 0.2.0-beta.7",
- "reth-nippy-jar 0.2.0-beta.7",
- "reth-node-api 0.2.0-beta.7",
- "reth-node-builder 0.2.0-beta.7",
- "reth-node-core 0.2.0-beta.7",
- "reth-node-ethereum 0.2.0-beta.7",
- "reth-node-events 0.2.0-beta.7",
- "reth-node-optimism 0.2.0-beta.7",
- "reth-optimism-primitives 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-payload-validator 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-rpc 0.2.0-beta.7",
- "reth-rpc-api 0.2.0-beta.7",
- "reth-rpc-builder 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
- "reth-stages 0.2.0-beta.7",
- "reth-static-file 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-tracing 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "serde",
- "serde_json",
- "similar-asserts",
- "tempfile",
- "tikv-jemallocator",
- "tokio",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "reth"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "ahash",
- "alloy-rlp",
- "aquamarine",
- "backon",
- "boyer-moore-magiclen",
- "clap",
- "comfy-table",
- "confy",
- "crossterm",
- "discv5",
- "eyre",
- "fdlimit",
- "futures",
- "human_bytes",
- "itertools 0.12.1",
- "libc",
- "metrics-process 2.0.0",
- "proptest",
- "rand 0.8.5",
- "ratatui",
- "rayon",
- "reth-basic-payload-builder 0.2.0-beta.8",
- "reth-beacon-consensus 0.2.0-beta.8",
- "reth-blockchain-tree 0.2.0-beta.8",
- "reth-cli-runner 0.2.0-beta.8",
- "reth-config 0.2.0-beta.8",
- "reth-consensus 0.2.0-beta.8",
- "reth-consensus-common 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
+ "metrics-process",
+ "reth-basic-payload-builder",
+ "reth-beacon-consensus",
+ "reth-blockchain-tree",
+ "reth-chainspec",
+ "reth-cli-commands",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-db",
  "reth-db-api",
- "reth-db-common 0.2.0-beta.8",
- "reth-discv4 0.2.0-beta.8",
- "reth-discv5 0.2.0-beta.8",
- "reth-downloaders 0.2.0-beta.8",
- "reth-errors 0.2.0-beta.8",
- "reth-ethereum-payload-builder 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-exex 0.2.0-beta.8",
- "reth-fs-util 0.2.0-beta.8",
- "reth-net-common 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-network-api 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-nippy-jar 0.2.0-beta.8",
- "reth-node-api 0.2.0-beta.8",
- "reth-node-builder 0.2.0-beta.8",
- "reth-node-core 0.2.0-beta.8",
- "reth-node-ethereum 0.2.0-beta.8",
- "reth-node-events 0.2.0-beta.8",
- "reth-node-optimism 0.2.0-beta.8",
- "reth-optimism-primitives 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-payload-validator 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-rpc 0.2.0-beta.8",
- "reth-rpc-api 0.2.0-beta.8",
- "reth-rpc-builder 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
- "reth-stages 0.2.0-beta.8",
- "reth-static-file 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
+ "reth-db-common",
+ "reth-downloaders",
+ "reth-engine-util",
+ "reth-errors",
+ "reth-ethereum-payload-builder",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-exex",
+ "reth-fs-util",
+ "reth-network",
+ "reth-network-api",
+ "reth-network-p2p",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-ethereum",
+ "reth-node-events",
+ "reth-node-optimism",
+ "reth-optimism-cli",
+ "reth-optimism-primitives",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-stages",
+ "reth-stages-api",
+ "reth-static-file",
+ "reth-static-file-types",
+ "reth-tasks",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "reth-trie",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5991,49 +5644,26 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "futures-util",
- "reth-beacon-consensus 0.2.0-beta.7",
- "reth-consensus 0.2.0-beta.7",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-network-p2p 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-stages-api 0.2.0-beta.7",
- "reth-tokio-util 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-auto-seal-consensus"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "futures-util",
- "reth-beacon-consensus 0.2.0-beta.8",
- "reth-consensus 0.2.0-beta.8",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-stages-api 0.2.0-beta.8",
- "reth-tokio-util 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-types",
+ "reth-stages-api",
+ "reth-tokio-util",
+ "reth-transaction-pool",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6041,44 +5671,22 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
  "futures-core",
  "futures-util",
- "metrics 0.21.1",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-interfaces",
- "reth-metrics 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "revm",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-basic-payload-builder"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "futures-core",
- "futures-util",
- "metrics 0.22.3",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
+ "metrics",
+ "reth-chainspec",
+ "reth-metrics",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-tasks",
+ "reth-transaction-pool",
  "revm",
  "tokio",
  "tracing",
@@ -6086,58 +5694,31 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "futures",
- "metrics 0.21.1",
- "reth-db 0.2.0-beta.7",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-ethereum-consensus 0.2.0-beta.7",
- "reth-interfaces",
- "reth-metrics 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-payload-validator 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-prune 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-stages-api 0.2.0-beta.7",
- "reth-static-file 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-tokio-util 0.2.0-beta.7",
- "schnellru",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-beacon-consensus"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "futures",
- "itertools 0.12.1",
- "metrics 0.22.3",
- "reth-blockchain-tree-api 0.2.0-beta.8",
+ "itertools 0.13.0",
+ "metrics",
+ "reth-blockchain-tree-api",
+ "reth-chainspec",
  "reth-db-api",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-errors 0.2.0-beta.8",
- "reth-ethereum-consensus 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-payload-validator 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-prune 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-stages-api 0.2.0-beta.8",
- "reth-static-file 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-tokio-util 0.2.0-beta.8",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-ethereum-consensus",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-rpc-types",
+ "reth-stages-api",
+ "reth-static-file",
+ "reth-tasks",
+ "reth-tokio-util",
  "schnellru",
  "thiserror",
  "tokio",
@@ -6147,270 +5728,259 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
- "metrics 0.21.1",
+ "metrics",
  "parking_lot 0.12.3",
- "reth-blockchain-tree-api 0.2.0-beta.7",
- "reth-consensus 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-network 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-stages-api 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "reth-trie-parallel 0.2.0-beta.7",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-blockchain-tree"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "aquamarine",
- "linked_hash_set",
- "metrics 0.22.3",
- "parking_lot 0.12.3",
- "reth-blockchain-tree-api 0.2.0-beta.8",
- "reth-consensus 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
+ "reth-blockchain-tree-api",
+ "reth-consensus",
+ "reth-db",
  "reth-db-api",
- "reth-evm 0.2.0-beta.8",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-stages-api 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
- "reth-trie-parallel 0.2.0-beta.8",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-network",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-revm",
+ "reth-stages-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-parallel",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-consensus 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-storage-errors",
  "thiserror",
 ]
 
 [[package]]
-name = "reth-blockchain-tree-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+name = "reth-chainspec"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-consensus 0.2.0-beta.8",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "thiserror",
-]
-
-[[package]]
-name = "reth-cli-runner"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "reth-tasks 0.2.0-beta.7",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-cli-runner"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-tasks 0.2.0-beta.8",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-chains",
+ "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs-derive 0.2.0-beta.7",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs-derive 0.2.0-beta.8",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "convert_case 0.6.0",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "convert_case 0.6.0",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "reth-config"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "confy",
- "humantime-serde",
- "reth-network 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "serde",
-]
-
-[[package]]
-name = "reth-config"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "confy",
- "humantime-serde",
- "reth-network 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "serde",
-]
-
-[[package]]
-name = "reth-consensus"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "auto_impl",
- "reth-primitives 0.2.0-beta.7",
- "thiserror",
-]
-
-[[package]]
-name = "reth-consensus"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "auto_impl",
- "reth-primitives 0.2.0-beta.8",
- "thiserror",
-]
-
-[[package]]
-name = "reth-consensus-common"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "reth-consensus 0.2.0-beta.7",
- "reth-optimism-primitives 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
-]
-
-[[package]]
-name = "reth-consensus-common"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-consensus 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
-]
-
-[[package]]
-name = "reth-db"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "arbitrary",
- "bytes",
+ "alloy-trie",
  "derive_more",
- "eyre",
- "metrics 0.21.1",
- "modular-bitfield",
  "once_cell",
- "page_size",
- "parity-scale-codec",
- "paste",
- "proptest",
- "proptest-derive",
- "reth-codecs 0.2.0-beta.7",
- "reth-fs-util 0.2.0-beta.7",
- "reth-libmdbx 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-nippy-jar 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "reth-tracing 0.2.0-beta.7",
- "rustc-hash",
+ "op-alloy-rpc-types",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-primitives-traits",
+ "reth-trie-common",
  "serde",
- "strum",
- "tempfile",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-cli"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "clap",
+ "eyre",
+ "reth-chainspec",
+ "reth-cli-runner",
+]
+
+[[package]]
+name = "reth-cli-commands"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "ahash",
+ "backon",
+ "clap",
+ "comfy-table",
+ "confy",
+ "crossterm",
+ "eyre",
+ "fdlimit",
+ "futures",
+ "human_bytes",
+ "itertools 0.13.0",
+ "metrics-process",
+ "ratatui",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-cli-runner",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-db-common",
+ "reth-downloaders",
+ "reth-evm",
+ "reth-exex",
+ "reth-fs-util",
+ "reth-network",
+ "reth-network-p2p",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-node-events",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages",
+ "reth-static-file",
+ "reth-static-file-types",
+ "reth-trie",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "reth-cli-runner"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "reth-tasks",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-cli-util"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "eyre",
+ "libc",
+ "rand 0.8.5",
+ "reth-fs-util",
+ "secp256k1",
  "thiserror",
 ]
 
 [[package]]
+name = "reth-codecs"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs-derive",
+ "serde",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "reth-config"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "confy",
+ "humantime-serde",
+ "reth-network-types",
+ "reth-prune-types",
+ "reth-stages-types",
+ "serde",
+]
+
+[[package]]
+name = "reth-consensus"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "auto_impl",
+ "reth-primitives",
+ "thiserror-no-std",
+]
+
+[[package]]
+name = "reth-consensus-common"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-primitives",
+]
+
+[[package]]
+name = "reth-consensus-debug-client"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-provider",
+ "auto_impl",
+ "eyre",
+ "futures",
+ "reqwest",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-types",
+ "reth-tracing",
+ "ringbuffer",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "reth-db"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "bytes",
  "derive_more",
  "eyre",
- "metrics 0.22.3",
+ "metrics",
  "page_size",
  "paste",
  "reth-db-api",
- "reth-fs-util 0.2.0-beta.8",
- "reth-libmdbx 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-nippy-jar 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
- "rustc-hash",
+ "reth-fs-util",
+ "reth-libmdbx",
+ "reth-metrics",
+ "reth-nippy-jar",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-tracing",
+ "reth-trie-common",
+ "rustc-hash 2.0.0",
  "serde",
  "strum",
  "sysinfo",
@@ -6420,57 +5990,45 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "arbitrary",
  "bytes",
  "derive_more",
- "metrics 0.22.3",
+ "metrics",
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
- "proptest-derive",
- "reth-codecs 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
+ "reth-codecs",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
  "serde",
 ]
 
 [[package]]
 name = "reth-db-common"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-genesis",
+ "boyer-moore-magiclen",
  "eyre",
- "reth-codecs 0.2.0-beta.7",
- "reth-config 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-etl 0.2.0-beta.7",
- "reth-interfaces",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-db-common"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "eyre",
- "reth-codecs 0.2.0-beta.8",
- "reth-config 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-config",
+ "reth-db",
  "reth-db-api",
- "reth-etl 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
+ "reth-etl",
+ "reth-fs-util",
+ "reth-primitives",
+ "reth-provider",
+ "reth-stages-types",
+ "reth-trie",
  "serde",
  "serde_json",
  "thiserror",
@@ -6479,43 +6037,21 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "discv5",
  "enr",
  "generic-array",
  "parking_lot 0.12.3",
- "reth-net-common 0.2.0-beta.7",
- "reth-net-nat 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
+ "reth-ethereum-forks",
+ "reth-net-banlist",
+ "reth-net-nat",
+ "reth-network-peers",
  "schnellru",
- "secp256k1 0.28.2",
- "serde",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-discv4"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "discv5",
- "enr",
- "generic-array",
- "parking_lot 0.12.3",
- "reth-net-common 0.2.0-beta.8",
- "reth-net-nat 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "schnellru",
- "secp256k1 0.28.2",
+ "secp256k1",
  "serde",
  "thiserror",
  "tokio",
@@ -6525,47 +6061,25 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-primitives",
  "alloy-rlp",
  "derive_more",
  "discv5",
  "enr",
  "futures",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "libp2p-identity",
- "metrics 0.21.1",
+ "metrics",
  "multiaddr",
  "rand 0.8.5",
- "reth-metrics 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "secp256k1 0.28.2",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-discv5"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "derive_more",
- "discv5",
- "enr",
- "futures",
- "itertools 0.12.1",
- "libp2p-identity",
- "metrics 0.22.3",
- "multiaddr",
- "rand 0.8.5",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "secp256k1 0.28.2",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-metrics",
+ "reth-network-peers",
+ "secp256k1",
  "thiserror",
  "tokio",
  "tracing",
@@ -6573,43 +6087,19 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-primitives",
  "data-encoding",
  "enr",
  "linked_hash_set",
  "parking_lot 0.12.3",
- "reth-net-common 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
+ "reth-ethereum-forks",
+ "reth-network-peers",
+ "reth-tokio-util",
  "schnellru",
- "secp256k1 0.28.2",
- "serde",
- "serde_with",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "reth-dns-discovery"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "data-encoding",
- "enr",
- "linked_hash_set",
- "parking_lot 0.12.3",
- "reth-net-common 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "schnellru",
- "secp256k1 0.28.2",
- "serde",
- "serde_with",
+ "secp256k1",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6619,51 +6109,24 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
  "futures",
  "futures-util",
- "itertools 0.12.1",
- "metrics 0.21.1",
+ "itertools 0.13.0",
+ "metrics",
  "pin-project",
  "rayon",
- "reth-config 0.2.0-beta.7",
- "reth-consensus 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-network-p2p 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "reth-downloaders"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "futures",
- "futures-util",
- "itertools 0.12.1",
- "metrics 0.22.3",
- "pin-project",
- "rayon",
- "reth-config 0.2.0-beta.8",
- "reth-consensus 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
+ "reth-config",
+ "reth-consensus",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-tasks",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6673,10 +6136,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "aes 0.8.4",
+ "alloy-primitives",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -6684,49 +6148,13 @@ dependencies = [
  "concat-kdf",
  "ctr 0.9.2",
  "digest 0.10.7",
- "educe",
  "futures",
  "generic-array",
  "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
- "reth-net-common 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "secp256k1 0.28.2",
- "sha2 0.10.8",
- "sha3",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "typenum",
-]
-
-[[package]]
-name = "reth-ecies"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "aes 0.8.4",
- "alloy-rlp",
- "block-padding",
- "byteorder",
- "cipher 0.4.4",
- "concat-kdf",
- "ctr 0.9.2",
- "digest 0.10.7",
- "educe",
- "futures",
- "generic-array",
- "hmac 0.12.1",
- "pin-project",
- "rand 0.8.5",
- "reth-net-common 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "secp256k1 0.28.2",
+ "reth-network-peers",
+ "secp256k1",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -6739,97 +6167,63 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-primitives 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
+ "reth-chainspec",
+ "reth-payload-primitives",
  "serde",
- "thiserror",
 ]
 
 [[package]]
-name = "reth-engine-primitives"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+name = "reth-engine-util"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-primitives 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "reth-errors"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "reth-blockchain-tree-api 0.2.0-beta.7",
- "reth-consensus 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-fs-util 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "thiserror",
-]
-
-[[package]]
-name = "reth-errors"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-blockchain-tree-api 0.2.0-beta.8",
- "reth-consensus 0.2.0-beta.8",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-fs-util 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "thiserror",
-]
-
-[[package]]
-name = "reth-eth-wire"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "derive_more",
+ "eyre",
  "futures",
- "metrics 0.21.1",
  "pin-project",
- "reth-codecs 0.2.0-beta.7",
- "reth-discv4 0.2.0-beta.7",
- "reth-ecies 0.2.0-beta.7",
- "reth-eth-wire-types 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
+ "reth-beacon-consensus",
+ "reth-engine-primitives",
+ "reth-fs-util",
+ "reth-rpc",
+ "reth-rpc-types",
  "serde",
- "snap",
- "thiserror",
- "tokio",
- "tokio-stream",
+ "serde_json",
  "tokio-util",
  "tracing",
 ]
 
 [[package]]
+name = "reth-errors"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "reth-blockchain-tree-api",
+ "reth-consensus",
+ "reth-execution-errors",
+ "reth-fs-util",
+ "reth-storage-errors",
+ "thiserror",
+]
+
+[[package]]
 name = "reth-eth-wire"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "derive_more",
  "futures",
  "pin-project",
- "reth-codecs 0.2.0-beta.8",
- "reth-discv4 0.2.0-beta.8",
- "reth-ecies 0.2.0-beta.8",
- "reth-eth-wire-types 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "serde",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-ecies",
+ "reth-eth-wire-types",
+ "reth-metrics",
+ "reth-network-peers",
+ "reth-primitives",
  "snap",
  "thiserror",
  "tokio",
@@ -6840,77 +6234,45 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-chains",
+ "alloy-genesis",
  "alloy-rlp",
  "bytes",
  "derive_more",
- "reth-codecs-derive 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "reth-eth-wire-types"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "derive_more",
- "reth-codecs-derive 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "serde",
+ "reth-chainspec",
+ "reth-codecs-derive",
+ "reth-primitives",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-consensus 0.2.0-beta.7",
- "reth-consensus-common 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
-]
-
-[[package]]
-name = "reth-ethereum-consensus"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-consensus 0.2.0-beta.8",
- "reth-consensus-common 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-primitives",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
- "revm-primitives",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "reth-ethereum-engine-primitives"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-evm-ethereum",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
  "revm-primitives",
  "serde",
  "sha2 0.10.8",
@@ -6918,85 +6280,47 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
+ "auto_impl",
  "crc",
+ "dyn-clone",
+ "once_cell",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.5.0",
+ "rustc-hash 2.0.0",
  "serde",
- "thiserror",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-chains",
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "crc",
- "proptest",
- "proptest-derive",
- "serde",
- "thiserror",
+ "thiserror-no-std",
 ]
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-basic-payload-builder 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-evm-ethereum 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "revm",
- "tracing",
-]
-
-[[package]]
-name = "reth-ethereum-payload-builder"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-basic-payload-builder 0.2.0-beta.8",
- "reth-errors 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-evm-ethereum 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
+ "reth-basic-payload-builder",
+ "reth-errors",
+ "reth-evm",
+ "reth-evm-ethereum",
+ "reth-execution-types",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-transaction-pool",
  "revm",
  "tracing",
 ]
 
 [[package]]
 name = "reth-etl"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "rayon",
- "reth-db 0.2.0-beta.7",
- "tempfile",
-]
-
-[[package]]
-name = "reth-etl"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7005,88 +6329,55 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-eips",
  "auto_impl",
  "futures-util",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "revm",
- "revm-primitives",
-]
-
-[[package]]
-name = "reth-evm"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "auto_impl",
- "futures-util",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-storage-errors",
  "revm",
  "revm-primitives",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-ethereum-consensus 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "revm-primitives",
-]
-
-[[package]]
-name = "reth-evm-ethereum"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-eips",
  "alloy-sol-types",
- "reth-ethereum-consensus 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-ethereum-consensus",
+ "reth-ethereum-forks",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-revm",
  "revm-primitives",
 ]
 
 [[package]]
 name = "reth-evm-optimism"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-consensus-common 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-optimism-consensus 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "revm",
- "revm-primitives",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-evm-optimism"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-consensus-common 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-optimism-consensus 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-consensus-common",
+ "reth-ethereum-forks",
+ "reth-evm",
+ "reth-execution-errors",
+ "reth-execution-types",
+ "reth-optimism-consensus",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-revm",
  "revm",
  "revm-primitives",
  "thiserror",
@@ -7095,147 +6386,79 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-consensus 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "thiserror",
-]
-
-[[package]]
-name = "reth-execution-errors"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-consensus 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "thiserror",
+ "alloy-eips",
+ "alloy-primitives",
+ "reth-consensus",
+ "reth-prune-types",
+ "reth-storage-errors",
+ "revm-primitives",
+ "thiserror-no-std",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "reth-evm 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "revm",
-]
-
-[[package]]
-name = "reth-execution-types"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-evm 0.2.0-beta.8",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-trie",
  "revm",
 ]
 
 [[package]]
 name = "reth-exex"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "eyre",
- "metrics 0.21.1",
- "reth-config 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-network 0.2.0-beta.7",
- "reth-node-api 0.2.0-beta.7",
- "reth-node-core 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-tracing 0.2.0-beta.7",
+ "metrics",
+ "reth-config",
+ "reth-evm",
+ "reth-exex-types",
+ "reth-metrics",
+ "reth-network",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-revm",
+ "reth-stages-api",
+ "reth-tasks",
+ "reth-tracing",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
-name = "reth-exex"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+name = "reth-exex-types"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "eyre",
- "metrics 0.22.3",
- "reth-config 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-node-api 0.2.0-beta.8",
- "reth-node-core 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
- "tokio",
- "tokio-util",
+ "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-fs-util"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "reth-fs-util"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "reth-interfaces"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "reth-blockchain-tree-api 0.2.0-beta.7",
- "reth-errors 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-network-p2p 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
 ]
 
 [[package]]
 name = "reth-ipc"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "futures-util",
- "interprocess",
- "jsonrpsee",
- "pin-project",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "reth-ipc"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7255,146 +6478,65 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "dashmap",
  "derive_more",
  "indexmap 2.2.6",
- "libc",
- "libffi",
  "parking_lot 0.12.3",
- "reth-mdbx-sys 0.2.0-beta.7",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-libmdbx"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "bitflags 2.5.0",
- "byteorder",
- "dashmap",
- "derive_more",
- "indexmap 2.2.6",
- "libc",
- "libffi",
- "parking_lot 0.12.3",
- "reth-mdbx-sys 0.2.0-beta.8",
+ "reth-mdbx-sys",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "bindgen",
  "cc",
- "libc",
-]
-
-[[package]]
-name = "reth-mdbx-sys"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "bindgen",
- "cc",
- "libc",
 ]
 
 [[package]]
 name = "reth-metrics"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "futures",
- "metrics 0.21.1",
- "reth-metrics-derive 0.2.0-beta.7",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "reth-metrics"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "futures",
- "metrics 0.22.3",
- "reth-metrics-derive 0.2.0-beta.8",
+ "metrics",
+ "reth-metrics-derive",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "reth-metrics-derive"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
-name = "reth-metrics-derive"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "reth-net-common"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+name = "reth-net-banlist"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-primitives",
- "pin-project",
- "tokio",
-]
-
-[[package]]
-name = "reth-net-common"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-primitives",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "igd-next",
- "pin-project-lite",
- "public-ip",
- "serde_with",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-net-nat"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -7405,8 +6547,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7414,83 +6556,35 @@ dependencies = [
  "derive_more",
  "discv5",
  "enr",
- "fnv",
  "futures",
- "futures-test",
  "humantime-serde",
- "itertools 0.12.1",
- "linked_hash_set",
- "metrics 0.21.1",
+ "itertools 0.13.0",
+ "metrics",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-consensus 0.2.0-beta.7",
- "reth-discv4 0.2.0-beta.7",
- "reth-discv5 0.2.0-beta.7",
- "reth-dns-discovery 0.2.0-beta.7",
- "reth-ecies 0.2.0-beta.7",
- "reth-eth-wire 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-net-common 0.2.0-beta.7",
- "reth-network-api 0.2.0-beta.7",
- "reth-network-p2p 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-tokio-util 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-discv4",
+ "reth-discv5",
+ "reth-dns-discovery",
+ "reth-ecies",
+ "reth-eth-wire",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-net-banlist",
+ "reth-network-api",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-network-types",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-tasks",
+ "reth-tokio-util",
+ "reth-transaction-pool",
+ "rustc-hash 2.0.0",
  "schnellru",
- "secp256k1 0.28.2",
- "serde",
- "serde_json",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "reth-network"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "aquamarine",
- "auto_impl",
- "derive_more",
- "discv5",
- "enr",
- "fnv",
- "futures",
- "humantime-serde",
- "itertools 0.12.1",
- "metrics 0.22.3",
- "parking_lot 0.12.3",
- "pin-project",
- "rand 0.8.5",
- "reth-consensus 0.2.0-beta.8",
- "reth-discv4 0.2.0-beta.8",
- "reth-discv5 0.2.0-beta.8",
- "reth-dns-discovery 0.2.0-beta.8",
- "reth-ecies 0.2.0-beta.8",
- "reth-eth-wire 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-net-common 0.2.0-beta.8",
- "reth-network-api 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-tokio-util 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
- "schnellru",
- "secp256k1 0.28.2",
+ "secp256k1",
  "serde",
  "serde_json",
  "smallvec",
@@ -7503,29 +6597,14 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-admin",
  "enr",
- "reth-eth-wire 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "serde",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "reth-network-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-primitives",
- "enr",
- "reth-eth-wire 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
+ "reth-eth-wire",
+ "reth-network-peers",
  "serde",
  "thiserror",
  "tokio",
@@ -7533,73 +6612,55 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "auto_impl",
  "futures",
- "reth-consensus 0.2.0-beta.7",
- "reth-eth-wire-types 0.2.0-beta.7",
- "reth-network-api 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
+ "reth-consensus",
+ "reth-eth-wire-types",
+ "reth-network-api",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-storage-errors",
  "thiserror",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "reth-network-p2p"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+name = "reth-network-peers"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "auto_impl",
- "futures",
- "reth-consensus 0.2.0-beta.8",
- "reth-eth-wire-types 0.2.0-beta.8",
- "reth-network-api 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
+ "alloy-primitives",
+ "alloy-rlp",
+ "enr",
+ "secp256k1",
+ "serde_with",
  "thiserror",
  "tokio",
+ "url",
+]
+
+[[package]]
+name = "reth-network-types"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "humantime-serde",
+ "reth-net-banlist",
+ "reth-network-api",
+ "reth-network-peers",
+ "serde",
+ "serde_json",
  "tracing",
-]
-
-[[package]]
-name = "reth-network-types"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "enr",
- "secp256k1 0.28.2",
- "serde_with",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "reth-network-types"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "enr",
- "secp256k1 0.28.2",
- "serde_with",
- "thiserror",
- "tokio",
- "url",
 ]
 
 [[package]]
 name = "reth-nippy-jar"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7608,27 +6669,7 @@ dependencies = [
  "lz4_flex",
  "memmap2",
  "ph",
- "reth-fs-util 0.2.0-beta.7",
- "serde",
- "sucds",
- "thiserror",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "reth-nippy-jar"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "anyhow",
- "bincode",
- "cuckoofilter",
- "derive_more",
- "lz4_flex",
- "memmap2",
- "ph",
- "reth-fs-util 0.2.0-beta.8",
+ "reth-fs-util",
  "serde",
  "sucds",
  "thiserror",
@@ -7638,81 +6679,24 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "reth-db 0.2.0-beta.7",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-network 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
-]
-
-[[package]]
-name = "reth-node-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "reth-db-api",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-network",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "reth-transaction-pool",
 ]
 
 [[package]]
 name = "reth-node-builder"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "aquamarine",
- "confy",
- "eyre",
- "fdlimit",
- "futures",
- "rayon",
- "reth-auto-seal-consensus 0.2.0-beta.7",
- "reth-beacon-consensus 0.2.0-beta.7",
- "reth-blockchain-tree 0.2.0-beta.7",
- "reth-config 0.2.0-beta.7",
- "reth-consensus 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-db-common 0.2.0-beta.7",
- "reth-downloaders 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-exex 0.2.0-beta.7",
- "reth-network 0.2.0-beta.7",
- "reth-network-p2p 0.2.0-beta.7",
- "reth-node-api 0.2.0-beta.7",
- "reth-node-core 0.2.0-beta.7",
- "reth-node-events 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-prune 0.2.0-beta.7",
- "reth-rpc 0.2.0-beta.7",
- "reth-rpc-engine-api 0.2.0-beta.7",
- "reth-rpc-layer 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-stages 0.2.0-beta.7",
- "reth-static-file 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-tracing 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "reth-node-builder"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "aquamarine",
  "backon",
@@ -7721,766 +6705,552 @@ dependencies = [
  "fdlimit",
  "futures",
  "rayon",
- "reth-auto-seal-consensus 0.2.0-beta.8",
- "reth-beacon-consensus 0.2.0-beta.8",
- "reth-blockchain-tree 0.2.0-beta.8",
- "reth-config 0.2.0-beta.8",
- "reth-consensus 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
+ "reth-auto-seal-consensus",
+ "reth-beacon-consensus",
+ "reth-blockchain-tree",
+ "reth-chainspec",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus",
+ "reth-consensus-debug-client",
+ "reth-db",
  "reth-db-api",
- "reth-db-common 0.2.0-beta.8",
- "reth-downloaders 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-exex 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-node-api 0.2.0-beta.8",
- "reth-node-core 0.2.0-beta.8",
- "reth-node-events 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-prune 0.2.0-beta.8",
- "reth-rpc 0.2.0-beta.8",
- "reth-rpc-engine-api 0.2.0-beta.8",
- "reth-rpc-layer 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-stages 0.2.0-beta.8",
- "reth-static-file 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
+ "reth-db-common",
+ "reth-downloaders",
+ "reth-engine-util",
+ "reth-evm",
+ "reth-exex",
+ "reth-network",
+ "reth-network-p2p",
+ "reth-node-api",
+ "reth-node-core",
+ "reth-node-events",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-rpc",
+ "reth-rpc-builder",
+ "reth-rpc-engine-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-layer",
+ "reth-rpc-types",
+ "reth-stages",
+ "reth-static-file",
+ "reth-tasks",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "secp256k1",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "reth-node-core"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "clap",
- "const-str",
- "derive_more",
- "dirs-next",
- "discv5",
- "eyre",
- "futures",
- "humantime",
- "hyper 0.14.29",
- "metrics 0.21.1",
- "metrics-exporter-prometheus 0.12.2",
- "metrics-process 1.0.14",
- "metrics-util 0.15.0",
- "once_cell",
- "pin-project",
- "procfs",
- "rand 0.8.5",
- "reth-beacon-consensus 0.2.0-beta.7",
- "reth-config 0.2.0-beta.7",
- "reth-consensus-common 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-discv4 0.2.0-beta.7",
- "reth-discv5 0.2.0-beta.7",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-fs-util 0.2.0-beta.7",
- "reth-interfaces",
- "reth-metrics 0.2.0-beta.7",
- "reth-net-nat 0.2.0-beta.7",
- "reth-network 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-rpc 0.2.0-beta.7",
- "reth-rpc-api 0.2.0-beta.7",
- "reth-rpc-builder 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-tracing 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "secp256k1 0.28.2",
- "serde",
- "serde_json",
- "shellexpand",
- "thiserror",
- "tikv-jemalloc-ctl",
- "tokio",
- "tokio-util",
  "tracing",
- "vergen",
 ]
 
 [[package]]
 name = "reth-node-core"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
+ "alloy-genesis",
+ "alloy-rpc-types-engine",
  "clap",
- "const-str",
+ "const_format",
  "derive_more",
  "dirs-next",
- "discv5",
  "eyre",
  "futures",
+ "http 1.1.0",
  "humantime",
- "hyper 0.14.29",
- "metrics 0.22.3",
- "metrics-exporter-prometheus 0.14.0",
- "metrics-process 2.0.0",
- "metrics-util 0.16.3",
+ "jsonrpsee",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-process",
+ "metrics-util",
  "once_cell",
- "pin-project",
  "procfs",
  "rand 0.8.5",
- "reth-beacon-consensus 0.2.0-beta.8",
- "reth-config 0.2.0-beta.8",
- "reth-consensus-common 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-cli-util",
+ "reth-config",
+ "reth-consensus-common",
+ "reth-db",
  "reth-db-api",
- "reth-discv4 0.2.0-beta.8",
- "reth-discv5 0.2.0-beta.8",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-fs-util 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-net-nat 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-rpc 0.2.0-beta.8",
- "reth-rpc-api 0.2.0-beta.8",
- "reth-rpc-builder 0.2.0-beta.8",
+ "reth-discv4",
+ "reth-discv5",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-net-nat",
+ "reth-network",
+ "reth-network-p2p",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-rpc-api",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
- "secp256k1 0.28.2",
- "serde",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-tasks",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "secp256k1",
  "serde_json",
  "shellexpand",
- "thiserror",
  "tikv-jemalloc-ctl",
  "tokio",
- "tokio-util",
- "tracing",
- "vergen",
-]
-
-[[package]]
-name = "reth-node-ethereum"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "eyre",
- "reth-basic-payload-builder 0.2.0-beta.7",
- "reth-ethereum-engine-primitives 0.2.0-beta.7",
- "reth-ethereum-payload-builder 0.2.0-beta.7",
- "reth-evm-ethereum 0.2.0-beta.7",
- "reth-network 0.2.0-beta.7",
- "reth-node-builder 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-tracing 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
-]
-
-[[package]]
-name = "reth-node-ethereum"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "eyre",
- "reth-basic-payload-builder 0.2.0-beta.8",
- "reth-ethereum-engine-primitives 0.2.0-beta.8",
- "reth-ethereum-payload-builder 0.2.0-beta.8",
- "reth-evm-ethereum 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-node-builder 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
-]
-
-[[package]]
-name = "reth-node-events"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "futures",
- "humantime",
- "pin-project",
- "reth-beacon-consensus 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-network 0.2.0-beta.7",
- "reth-network-api 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-prune 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-stages 0.2.0-beta.7",
- "reth-static-file 0.2.0-beta.7",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-node-events"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "futures",
- "humantime",
- "pin-project",
- "reth-beacon-consensus 0.2.0-beta.8",
- "reth-db-api",
- "reth-network 0.2.0-beta.8",
- "reth-network-api 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-prune 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-stages 0.2.0-beta.8",
- "reth-static-file 0.2.0-beta.8",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-node-optimism"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "async-trait",
- "clap",
- "eyre",
- "hyper 0.14.29",
- "jsonrpsee",
- "parking_lot 0.12.3",
- "reqwest",
- "reth-basic-payload-builder 0.2.0-beta.7",
- "reth-beacon-consensus 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-evm-optimism 0.2.0-beta.7",
- "reth-interfaces",
- "reth-network 0.2.0-beta.7",
- "reth-node-api 0.2.0-beta.7",
- "reth-node-builder 0.2.0-beta.7",
- "reth-optimism-payload-builder 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-rpc 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
- "reth-tracing 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "revm",
- "revm-primitives",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-node-optimism"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "async-trait",
- "clap",
- "eyre",
- "hyper 0.14.29",
- "jsonrpsee",
- "parking_lot 0.12.3",
- "reqwest",
- "reth-basic-payload-builder 0.2.0-beta.8",
- "reth-beacon-consensus 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-evm-optimism 0.2.0-beta.8",
- "reth-network 0.2.0-beta.8",
- "reth-node-api 0.2.0-beta.8",
- "reth-node-builder 0.2.0-beta.8",
- "reth-optimism-payload-builder 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-rpc 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
- "reth-tracing 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
- "revm-primitives",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-optimism-consensus"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "reth-consensus 0.2.0-beta.7",
- "reth-consensus-common 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
-]
-
-[[package]]
-name = "reth-optimism-consensus"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-consensus 0.2.0-beta.8",
- "reth-consensus-common 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
-]
-
-[[package]]
-name = "reth-optimism-payload-builder"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-rlp",
- "reth-basic-payload-builder 0.2.0-beta.7",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-evm-optimism 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "revm",
- "sha2 0.10.8",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-optimism-payload-builder"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "reth-basic-payload-builder 0.2.0-beta.8",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-evm-optimism 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
- "revm",
- "sha2 0.10.8",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-optimism-primitives"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-
-[[package]]
-name = "reth-optimism-primitives"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-
-[[package]]
-name = "reth-payload-builder"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "futures-util",
- "metrics 0.21.1",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-ethereum-engine-primitives 0.2.0-beta.7",
- "reth-interfaces",
- "reth-metrics 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-payload-builder"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "futures-util",
- "metrics 0.22.3",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-errors 0.2.0-beta.8",
- "reth-ethereum-engine-primitives 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-payload-validator"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "reth-primitives 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
-]
-
-[[package]]
-name = "reth-payload-validator"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-primitives 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-chains",
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "arbitrary",
- "byteorder",
- "bytes",
- "c-kzg",
- "derive_more",
- "itertools 0.12.1",
- "modular-bitfield",
- "nybbles",
- "once_cell",
- "proptest",
- "proptest-derive",
- "rayon",
- "reth-codecs 0.2.0-beta.7",
- "reth-ethereum-forks 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-static-file-types 0.2.0-beta.7",
- "revm",
- "revm-primitives",
- "roaring",
- "secp256k1 0.28.2",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
- "zstd",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-chains",
- "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-trie",
- "arbitrary",
- "byteorder",
- "bytes",
- "c-kzg",
- "derive_more",
- "itertools 0.12.1",
- "modular-bitfield",
- "nybbles",
- "once_cell",
- "proptest",
- "proptest-derive",
- "rayon",
- "reth-codecs 0.2.0-beta.8",
- "reth-ethereum-forks 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-static-file-types 0.2.0-beta.8",
- "revm",
- "revm-primitives",
- "roaring",
- "secp256k1 0.28.2",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
- "zstd",
-]
-
-[[package]]
-name = "reth-provider"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-rlp",
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "auto_impl",
- "dashmap",
- "itertools 0.12.1",
- "metrics 0.21.1",
- "parking_lot 0.12.3",
- "pin-project",
- "rayon",
- "reth-blockchain-tree-api 0.2.0-beta.7",
- "reth-codecs 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-execution-types 0.2.0-beta.7",
- "reth-fs-util 0.2.0-beta.7",
- "reth-interfaces",
- "reth-metrics 0.2.0-beta.7",
- "reth-nippy-jar 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-api 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "revm",
- "strum",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-provider"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "auto_impl",
- "dashmap",
- "itertools 0.12.1",
- "metrics 0.22.3",
- "parking_lot 0.12.3",
- "pin-project",
- "rayon",
- "reth-blockchain-tree-api 0.2.0-beta.8",
- "reth-codecs 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
- "reth-db-api",
- "reth-errors 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-execution-types 0.2.0-beta.8",
- "reth-fs-util 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-nippy-jar 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-api 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
- "revm",
- "strum",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-prune"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "itertools 0.12.1",
- "metrics 0.21.1",
- "rayon",
- "reth-config 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-interfaces",
- "reth-metrics 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-tokio-util 0.2.0-beta.7",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-prune"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "itertools 0.12.1",
- "metrics 0.22.3",
- "rayon",
- "reth-config 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
- "reth-db-api",
- "reth-errors 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-tokio-util 0.2.0-beta.8",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-revm"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "reth-consensus-common 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-api 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "revm",
- "tracing",
-]
-
-[[package]]
-name = "reth-revm"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-rlp",
- "reth-consensus-common 0.2.0-beta.8",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-api 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "revm",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-dyn-abi",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-sol-types",
- "async-trait",
- "derive_more",
- "dyn-clone",
- "futures",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.29",
- "jsonrpsee",
- "jsonwebtoken 8.3.0",
- "metrics 0.21.1",
- "parking_lot 0.12.3",
- "pin-project",
- "rand 0.8.5",
- "reth-consensus-common 0.2.0-beta.7",
- "reth-errors 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-evm-optimism 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-network-api 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-rpc-api 0.2.0-beta.7",
- "reth-rpc-engine-api 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "revm",
- "revm-inspectors 0.1.0 (git+https://github.com/paradigmxyz/evm-inspectors?rev=ed5450e)",
- "revm-primitives",
- "schnellru",
- "secp256k1 0.28.2",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-stream",
  "tower",
  "tracing",
- "tracing-futures",
+ "vergen",
+]
+
+[[package]]
+name = "reth-node-ethereum"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "eyre",
+ "reth-auto-seal-consensus",
+ "reth-basic-payload-builder",
+ "reth-beacon-consensus",
+ "reth-consensus",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-payload-builder",
+ "reth-evm-ethereum",
+ "reth-network",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-payload-builder",
+ "reth-provider",
+ "reth-rpc",
+ "reth-tracing",
+ "reth-transaction-pool",
+]
+
+[[package]]
+name = "reth-node-events"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-rpc-types-engine",
+ "futures",
+ "humantime",
+ "pin-project",
+ "reth-beacon-consensus",
+ "reth-db-api",
+ "reth-network",
+ "reth-network-api",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages",
+ "reth-static-file",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-node-optimism"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "async-trait",
+ "clap",
+ "eyre",
+ "jsonrpsee",
+ "jsonrpsee-types",
+ "parking_lot 0.12.3",
+ "reqwest",
+ "reth-auto-seal-consensus",
+ "reth-basic-payload-builder",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-discv5",
+ "reth-evm",
+ "reth-evm-optimism",
+ "reth-network",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-optimism-consensus",
+ "reth-optimism-payload-builder",
+ "reth-optimism-rpc",
+ "reth-payload-builder",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-tasks",
+ "reth-tracing",
+ "reth-transaction-pool",
+ "revm-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-cli"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "clap",
+ "eyre",
+ "futures-util",
+ "reth-chainspec",
+ "reth-cli",
+ "reth-cli-commands",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-downloaders",
+ "reth-errors",
+ "reth-evm-optimism",
+ "reth-execution-types",
+ "reth-network-p2p",
+ "reth-node-core",
+ "reth-node-events",
+ "reth-optimism-primitives",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages",
+ "reth-stages-types",
+ "reth-static-file",
+ "reth-static-file-types",
+ "serde_json",
+ "shellexpand",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-consensus"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-primitives",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-payload-builder"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-rlp",
+ "reth-basic-payload-builder",
+ "reth-chainspec",
+ "reth-evm",
+ "reth-evm-optimism",
+ "reth-execution-types",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-transaction-pool",
+ "revm",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "reth-optimism-primitives"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+
+[[package]]
+name = "reth-optimism-rpc"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-primitives",
+ "jsonrpsee",
+ "parking_lot 0.12.3",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-evm",
+ "reth-evm-optimism",
+ "reth-node-api",
+ "reth-primitives",
+ "reth-provider",
+ "reth-rpc",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "revm",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "reth-payload-builder"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "futures-util",
+ "metrics",
+ "reth-errors",
+ "reth-ethereum-engine-primitives",
+ "reth-metrics",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-provider",
+ "reth-rpc-types",
+ "reth-transaction-pool",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-payload-primitives"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "reth-chainspec",
+ "reth-errors",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-transaction-pool",
+ "serde",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "reth-payload-validator"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "reth-chainspec",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+]
+
+[[package]]
+name = "reth-primitives"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "arbitrary",
+ "bytes",
+ "c-kzg",
+ "derive_more",
+ "modular-bitfield",
+ "once_cell",
+ "proptest",
+ "rayon",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-ethereum-forks",
+ "reth-primitives-traits",
+ "reth-static-file-types",
+ "reth-trie-common",
+ "revm-primitives",
+ "secp256k1",
+ "serde",
+ "tempfile",
+ "thiserror-no-std",
+ "zstd",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "arbitrary",
+ "byteorder",
+ "bytes",
+ "derive_more",
+ "modular-bitfield",
+ "proptest",
+ "proptest-arbitrary-interop",
+ "reth-codecs",
+ "revm-primitives",
+ "roaring",
+ "serde",
+ "thiserror-no-std",
+]
+
+[[package]]
+name = "reth-provider"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "dashmap",
+ "derive_more",
+ "itertools 0.13.0",
+ "metrics",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rayon",
+ "reth-blockchain-tree-api",
+ "reth-chainspec",
+ "reth-codecs",
+ "reth-db",
+ "reth-db-api",
+ "reth-errors",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-nippy-jar",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "revm",
+ "strum",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "reth-prune"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-primitives",
+ "itertools 0.13.0",
+ "metrics",
+ "rayon",
+ "reth-chainspec",
+ "reth-config",
+ "reth-db",
+ "reth-db-api",
+ "reth-errors",
+ "reth-exex-types",
+ "reth-metrics",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-static-file-types",
+ "reth-tokio-util",
+ "rustc-hash 2.0.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-prune-types"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "derive_more",
+ "modular-bitfield",
+ "reth-codecs",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-revm"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-eips",
+ "reth-chainspec",
+ "reth-consensus-common",
+ "reth-execution-errors",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "revm",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-rpc"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-dyn-abi",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-sol-types",
  "async-trait",
  "derive_more",
- "dyn-clone",
  "futures",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.29",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
  "jsonrpsee",
- "jsonwebtoken 8.3.0",
- "metrics 0.22.3",
+ "jsonrpsee-types",
+ "jsonwebtoken",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "reth-consensus-common 0.2.0-beta.8",
- "reth-errors 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-evm-optimism 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-api 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-rpc-api 0.2.0-beta.8",
- "reth-rpc-engine-api 0.2.0-beta.8",
+ "reth-chainspec",
+ "reth-consensus-common",
+ "reth-errors",
+ "reth-evm",
+ "reth-network-api",
+ "reth-network-peers",
+ "reth-node-api",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-api",
+ "reth-rpc-engine-api",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-tasks",
+ "reth-transaction-pool",
  "revm",
- "revm-inspectors 0.1.0 (git+https://github.com/paradigmxyz/evm-inspectors?rev=421f9e4)",
+ "revm-inspectors",
  "revm-primitives",
- "schnellru",
- "secp256k1 0.28.2",
+ "secp256k1",
  "serde",
  "serde_json",
  "thiserror",
@@ -8493,83 +7263,43 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "jsonrpsee",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-network-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
+ "reth-engine-primitives",
+ "reth-network-peers",
+ "reth-primitives",
+ "reth-rpc-eth-api",
+ "reth-rpc-types",
  "serde",
- "serde_json",
-]
-
-[[package]]
-name = "reth-rpc-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "jsonrpsee",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-network-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "hyper 0.14.29",
+ "http 1.1.0",
  "jsonrpsee",
- "metrics 0.21.1",
+ "metrics",
  "pin-project",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-ipc 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-network-api 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-rpc 0.2.0-beta.7",
- "reth-rpc-api 0.2.0-beta.7",
- "reth-rpc-layer 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-transaction-pool 0.2.0-beta.7",
- "serde",
- "strum",
- "thiserror",
- "tower",
- "tower-http",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc-builder"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "hyper 0.14.29",
- "jsonrpsee",
- "metrics 0.22.3",
- "pin-project",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-ipc 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-api 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-rpc 0.2.0-beta.8",
- "reth-rpc-api 0.2.0-beta.8",
- "reth-rpc-layer 0.2.0-beta.8",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-ipc",
+ "reth-metrics",
+ "reth-network-api",
+ "reth-node-core",
+ "reth-provider",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
+ "reth-rpc-layer",
  "reth-rpc-server-types",
- "reth-tasks 0.2.0-beta.8",
- "reth-transaction-pool 0.2.0-beta.8",
+ "reth-tasks",
+ "reth-transaction-pool",
  "serde",
- "strum",
  "thiserror",
  "tower",
  "tower-http",
@@ -8578,23 +7308,26 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "metrics 0.21.1",
- "reth-beacon-consensus 0.2.0-beta.7",
- "reth-engine-primitives 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-payload-builder 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-rpc-api 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
- "reth-rpc-types-compat 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
+ "metrics",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-engine-primitives",
+ "reth-evm",
+ "reth-metrics",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives",
+ "reth-rpc-api",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-storage-api",
+ "reth-tasks",
  "serde",
  "thiserror",
  "tokio",
@@ -8602,54 +7335,82 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-engine-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+name = "reth-rpc-eth-api"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-dyn-abi",
  "async-trait",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "metrics 0.22.3",
- "reth-beacon-consensus 0.2.0-beta.8",
- "reth-engine-primitives 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-payload-builder 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-rpc-api 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
- "reth-rpc-types-compat 0.2.0-beta.8",
- "reth-storage-api 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "serde",
- "thiserror",
+ "auto_impl",
+ "dyn-clone",
+ "futures",
+ "jsonrpsee",
+ "parking_lot 0.12.3",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-eth-types",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "revm",
+ "revm-inspectors",
+ "revm-primitives",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "reth-rpc-layer"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+name = "reth-rpc-eth-types"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.29",
- "pin-project",
- "tower",
+ "alloy-sol-types",
+ "derive_more",
+ "futures",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "metrics",
+ "rand 0.8.5",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc-server-types",
+ "reth-rpc-types",
+ "reth-rpc-types-compat",
+ "reth-tasks",
+ "reth-transaction-pool",
+ "reth-trie",
+ "revm",
+ "revm-inspectors",
+ "revm-primitives",
+ "schnellru",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-layer"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.29",
+ "alloy-rpc-types-engine",
+ "http 1.1.0",
+ "jsonrpsee-http-client",
  "pin-project",
  "tower",
  "tracing",
@@ -8657,220 +7418,147 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-primitives",
-]
-
-[[package]]
-name = "reth-rpc-types"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-rpc-types-anvil 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-rpc-types-beacon 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "jsonrpsee-core",
  "jsonrpsee-types",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "reth-rpc-types"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-rpc-types-anvil 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-rpc-types-beacon 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-rpc-types-engine 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "jsonrpsee-types",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "reth-rpc-types-compat"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "reth-primitives 0.2.0-beta.7",
- "reth-rpc-types 0.2.0-beta.7",
-]
-
-[[package]]
-name = "reth-rpc-types-compat"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "reth-primitives 0.2.0-beta.8",
- "reth-rpc-types 0.2.0-beta.8",
-]
-
-[[package]]
-name = "reth-stages"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "futures-util",
- "itertools 0.12.1",
- "num-traits",
- "rayon",
- "reth-codecs 0.2.0-beta.7",
- "reth-config 0.2.0-beta.7",
- "reth-consensus 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-etl 0.2.0-beta.7",
- "reth-evm 0.2.0-beta.7",
- "reth-exex 0.2.0-beta.7",
- "reth-interfaces",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-revm 0.2.0-beta.7",
- "reth-stages-api 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-stages"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "futures-util",
- "itertools 0.12.1",
- "num-traits",
- "rayon",
- "reth-codecs 0.2.0-beta.8",
- "reth-config 0.2.0-beta.8",
- "reth-consensus 0.2.0-beta.8",
- "reth-db 0.2.0-beta.8",
- "reth-db-api",
- "reth-etl 0.2.0-beta.8",
- "reth-evm 0.2.0-beta.8",
- "reth-exex 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-revm 0.2.0-beta.8",
- "reth-stages-api 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-stages-api"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "aquamarine",
- "auto_impl",
- "futures-util",
- "metrics 0.21.1",
- "reth-consensus 0.2.0-beta.7",
- "reth-db 0.2.0-beta.7",
- "reth-interfaces",
- "reth-metrics 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-prune 0.2.0-beta.7",
- "reth-static-file 0.2.0-beta.7",
- "reth-tokio-util 0.2.0-beta.7",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-stages-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "aquamarine",
- "auto_impl",
- "futures-util",
- "metrics 0.22.3",
- "reth-consensus 0.2.0-beta.8",
- "reth-db-api",
- "reth-errors 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-network-p2p 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-prune 0.2.0-beta.8",
- "reth-static-file 0.2.0-beta.8",
- "reth-tokio-util 0.2.0-beta.8",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-static-file"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "parking_lot 0.12.3",
- "rayon",
- "reth-db 0.2.0-beta.7",
- "reth-nippy-jar 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "reth-tokio-util 0.2.0-beta.7",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-static-file"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "parking_lot 0.12.3",
- "rayon",
- "reth-db 0.2.0-beta.8",
- "reth-db-api",
- "reth-nippy-jar 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "reth-tokio-util 0.2.0-beta.8",
- "tracing",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "alloy-primitives",
- "clap",
- "derive_more",
+ "reth-errors",
+ "reth-network-api",
+ "reth-primitives",
+ "reth-rpc-types",
  "serde",
  "strum",
 ]
 
 [[package]]
+name = "reth-rpc-types"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-rpc-types-admin",
+ "alloy-rpc-types-anvil",
+ "alloy-rpc-types-beacon",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-mev",
+ "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
+ "alloy-serde",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "reth-rpc-types-compat"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-rlp",
+ "alloy-rpc-types",
+ "reth-primitives",
+ "reth-rpc-types",
+ "reth-trie-common",
+]
+
+[[package]]
+name = "reth-stages"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "futures-util",
+ "itertools 0.13.0",
+ "num-traits",
+ "rayon",
+ "reth-codecs",
+ "reth-config",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-etl",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-exex",
+ "reth-network-p2p",
+ "reth-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-prune-types",
+ "reth-revm",
+ "reth-stages-api",
+ "reth-storage-errors",
+ "reth-trie",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-stages-api"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-primitives",
+ "aquamarine",
+ "auto_impl",
+ "futures-util",
+ "metrics",
+ "reth-consensus",
+ "reth-db-api",
+ "reth-errors",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages-types",
+ "reth-static-file",
+ "reth-static-file-types",
+ "reth-tokio-util",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "reth-stages-types"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-primitives",
+ "bytes",
+ "modular-bitfield",
+ "reth-codecs",
+ "reth-trie-common",
+ "serde",
+]
+
+[[package]]
+name = "reth-static-file"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+dependencies = [
+ "alloy-primitives",
+ "parking_lot 0.12.3",
+ "rayon",
+ "reth-db",
+ "reth-db-api",
+ "reth-nippy-jar",
+ "reth-provider",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-static-file-types",
+ "reth-storage-errors",
+ "reth-tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "reth-static-file-types"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8881,81 +7569,43 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "auto_impl",
- "reth-db 0.2.0-beta.7",
- "reth-execution-types 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-storage-errors 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "revm",
-]
-
-[[package]]
-name = "reth-storage-api"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "auto_impl",
+ "reth-chainspec",
  "reth-db-api",
- "reth-execution-types 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-storage-errors 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
+ "reth-execution-types",
+ "reth-primitives",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie",
  "revm",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
- "clap",
- "reth-fs-util 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "thiserror",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "reth-fs-util 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "thiserror",
+ "reth-fs-util",
+ "reth-primitives",
+ "thiserror-no-std",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "auto_impl",
  "dyn-clone",
  "futures-util",
- "metrics 0.21.1",
+ "metrics",
  "pin-project",
  "rayon",
- "reth-metrics 0.2.0-beta.7",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "reth-tasks"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "dyn-clone",
- "futures-util",
- "metrics 0.22.3",
- "pin-project",
- "rayon",
- "reth-metrics 0.2.0-beta.8",
+ "reth-metrics",
  "thiserror",
  "tokio",
  "tracing",
@@ -8964,18 +7614,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-tokio-util"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -8984,23 +7624,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
-dependencies = [
- "clap",
- "eyre",
- "rolling-file",
- "tracing",
- "tracing-appender",
- "tracing-journald",
- "tracing-logfmt",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "reth-tracing"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "clap",
  "eyre",
@@ -9014,57 +7639,26 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "futures-util",
- "itertools 0.12.1",
- "metrics 0.21.1",
+ "metrics",
  "parking_lot 0.12.3",
- "paste",
- "rand 0.8.5",
- "reth-eth-wire-types 0.2.0-beta.7",
- "reth-fs-util 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "rustc-hash",
- "schnellru",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-transaction-pool"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "aquamarine",
- "auto_impl",
- "bitflags 2.5.0",
- "futures-util",
- "itertools 0.12.1",
- "metrics 0.22.3",
- "parking_lot 0.12.3",
- "paste",
- "rand 0.8.5",
- "reth-eth-wire-types 0.2.0-beta.8",
- "reth-fs-util 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "rustc-hash",
+ "reth-chainspec",
+ "reth-eth-wire-types",
+ "reth-execution-types",
+ "reth-fs-util",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "revm",
+ "rustc-hash 2.0.0",
  "schnellru",
  "serde",
  "smallvec",
@@ -9076,81 +7670,64 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
  "derive_more",
- "metrics 0.21.1",
- "reth-db 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "revm",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
-dependencies = [
- "alloy-rlp",
- "auto_impl",
- "derive_more",
- "metrics 0.22.3",
+ "itertools 0.13.0",
+ "metrics",
  "rayon",
- "reth-db 0.2.0-beta.8",
+ "reth-db",
  "reth-db-api",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-stages-types",
+ "reth-trie-common",
  "revm",
  "tracing",
 ]
 
 [[package]]
-name = "reth-trie-parallel"
-version = "0.2.0-beta.7"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=76b32c8#76b32c8b5f3b9937ca507c75b4ba53cb0c83915e"
+name = "reth-trie-common"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
+ "alloy-consensus",
+ "alloy-genesis",
+ "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
+ "bytes",
  "derive_more",
- "itertools 0.12.1",
- "metrics 0.21.1",
- "rayon",
- "reth-db 0.2.0-beta.7",
- "reth-execution-errors 0.2.0-beta.7",
- "reth-metrics 0.2.0-beta.7",
- "reth-primitives 0.2.0-beta.7",
- "reth-provider 0.2.0-beta.7",
- "reth-tasks 0.2.0-beta.7",
- "reth-trie 0.2.0-beta.7",
- "thiserror",
- "tokio",
- "tracing",
+ "itertools 0.13.0",
+ "nybbles",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "revm-primitives",
+ "serde",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "0.2.0-beta.8"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=40d8ac0#40d8ac099f1bf9eb9640ddf0665e9c7461c0f80a"
+version = "1.0.2"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
 dependencies = [
  "alloy-rlp",
  "derive_more",
- "itertools 0.12.1",
- "metrics 0.22.3",
+ "itertools 0.13.0",
+ "metrics",
  "rayon",
- "reth-db 0.2.0-beta.8",
+ "reth-db",
  "reth-db-api",
- "reth-execution-errors 0.2.0-beta.8",
- "reth-metrics 0.2.0-beta.8",
- "reth-primitives 0.2.0-beta.8",
- "reth-provider 0.2.0-beta.8",
- "reth-tasks 0.2.0-beta.8",
- "reth-trie 0.2.0-beta.8",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-provider",
+ "reth-tasks",
+ "reth-trie",
  "thiserror",
  "tokio",
  "tracing",
@@ -9158,8 +7735,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "9.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+version = "12.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cfb48bce8ca2113e157bdbddbd5eeb09daac1c903d79ec17085897c38c7c91"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9172,30 +7750,12 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=421f9e4#421f9e4697d0caf8ad3fe1c9061fee7ed87d2697"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d37905c9d80d261bb24692b3627b00c4827d0aa9fb9e48271aa5d9ffcba06ca"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=5796024)",
- "alloy-sol-types",
- "anstyle",
- "boa_engine",
- "boa_gc",
- "colorchoice",
- "revm",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "revm-inspectors"
-version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors?rev=ed5450e#ed5450e7169ce0237e791fed661688c55997a0ac"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
- "alloy-rpc-types-trace 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=bd39117)",
+ "alloy-rpc-types",
  "alloy-sol-types",
  "anstyle",
  "boa_engine",
@@ -9208,8 +7768,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "5.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b0daddea06fc6da5346acc39b32a357bbe3579e9e3d94117d9ae125cd596fc"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -9217,30 +7778,34 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "7.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+version = "9.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef55228211251d7b6c7707c3ee13bb70dea4d2fd81ec4034521e4fe31010b2ea"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
+ "cfg-if",
  "k256",
  "once_cell",
  "p256",
  "revm-primitives",
  "ripemd",
- "secp256k1 0.29.0",
+ "secp256k1",
  "sha2 0.10.8",
  "substrate-bn",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "4.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=a28a543#a28a5439b9cfb7494cbd670da10cbedcfe6c5854"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc4311037ee093ec50ec734e1424fcb3e12d535c6cef683b75d1c064639630c"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "auto_impl",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bitvec",
  "c-kzg",
  "cfg-if",
@@ -9249,6 +7814,7 @@ dependencies = [
  "enumn",
  "hashbrown 0.14.5",
  "hex",
+ "kzg-rs",
  "once_cell",
  "serde",
 ]
@@ -9265,21 +7831,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -9288,10 +7839,16 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "ringbuffer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "ripemd"
@@ -9323,9 +7880,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7699249cc2c7d71939f30868f47e9d7add0bdc030d90ee10bfd16887ff8bb1c8"
+checksum = "8f4b84ba6e838ceb47b41de5194a60244fac43d9fe03b71dbe8c5a201081d6d1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -9371,7 +7928,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.0",
- "syn 2.0.66",
+ "syn 2.0.71",
  "unicode-ident",
 ]
 
@@ -9419,6 +7976,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9448,7 +8011,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -9457,62 +8020,30 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "log",
- "ring 0.17.8",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring 0.17.8",
+ "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -9532,24 +8063,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-platform-verifier"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "3e3beb939bcd33c269f4bf946cc829fcd336370267c4a927ac0399c84a3151a1"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots",
+ "winapi",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.102.4"
+name = "rustls-platform-verifier-android"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -9594,6 +8142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9620,16 +8177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9645,32 +8192,13 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
-dependencies = [
- "rand 0.8.5",
- "secp256k1-sys 0.9.2",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "rand 0.8.5",
- "secp256k1-sys 0.10.0",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
-dependencies = [
- "cc",
+ "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -9684,22 +8212,23 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -9739,39 +8268,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
-name = "serde"
-version = "1.0.203"
+name = "send_wrapper"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -9802,9 +8337,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -9820,27 +8355,38 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
- "darling 0.20.9",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.8"
+name = "serde_yaml"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "block-buffer 0.9.0",
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -10010,7 +8556,6 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
- "arbitrary",
  "serde",
 ]
 
@@ -10042,40 +8587,25 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes",
  "futures",
- "http 0.2.12",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1",
+ "sha1",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -10095,12 +8625,12 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stability"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -10117,21 +8647,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
@@ -10146,7 +8670,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -10164,9 +8688,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sucds"
@@ -10191,9 +8715,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10202,21 +8726,21 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d71e19bca02c807c9faa67b5a47673ff231b6e7449b251695188522f1dc44b2"
+checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -10226,21 +8750,20 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.30.12"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
  "libc",
  "ntapi",
  "once_cell",
- "rayon",
  "windows 0.52.0",
 ]
 
@@ -10270,22 +8793,42 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "thiserror-impl-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]
@@ -10393,9 +8936,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -10407,16 +8950,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "to_method"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
-
-[[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10439,7 +8976,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -10454,21 +8991,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -10483,6 +9010,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -10509,7 +9052,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.15",
 ]
 
 [[package]]
@@ -10534,9 +9077,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.14"
+version = "0.22.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -10568,18 +9111,19 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
  "http-range-header",
  "httpdate",
  "iri-string",
@@ -10640,7 +9184,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -10659,8 +9203,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -10731,51 +9273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-client"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4ef9b9bde0559b78a4abb00339143750085f05e5a453efb7b8bef1061f09dc"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "log",
- "radix_trie",
- "rand 0.8.5",
- "thiserror",
- "time",
- "tokio",
- "trust-dns-proto 0.20.4",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.3.4",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "log",
- "rand 0.8.5",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "trust-dns-proto"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10784,7 +9281,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner 0.6.0",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
@@ -10818,7 +9315,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "trust-dns-proto 0.23.2",
+ "trust-dns-proto",
 ]
 
 [[package]]
@@ -10826,6 +9323,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -10896,11 +9413,12 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5fbabedabe362c618c714dbefda9927b5afc8e2a8102f47f081089a9019226"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools 0.12.1",
+ "itertools 0.13.0",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -10911,6 +9429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "universal-hash"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10919,6 +9443,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
@@ -10934,26 +9464,26 @@ checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.0",
+ "idna 0.5.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -10975,9 +9505,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.15",
 ]
@@ -10996,9 +9526,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.3.1"
+version = "8.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
+checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -11027,6 +9557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -11071,7 +9611,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -11105,7 +9645,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -11127,10 +9667,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.2"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11158,6 +9708,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11170,17 +9729,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.56.0",
- "windows-targets 0.52.5",
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11189,41 +9748,41 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -11232,7 +9791,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11250,7 +9809,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11270,18 +9829,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -11292,9 +9851,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -11304,9 +9863,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11316,15 +9875,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -11334,9 +9893,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11346,9 +9905,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11358,9 +9917,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11370,9 +9929,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -11425,6 +9984,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.0",
+ "send_wrapper 0.6.0",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wyhash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11440,21 +10018,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
-
-[[package]]
-name = "xmltree"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
-dependencies = [
- "xml-rs",
 ]
 
 [[package]]
@@ -11477,28 +10040,28 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -11518,7 +10081,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
  "synstructure",
 ]
 
@@ -11539,14 +10102,14 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -11555,38 +10118,38 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -5645,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "reth-auto-seal-consensus"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -5695,7 +5695,7 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "futures",
  "itertools 0.13.0",
@@ -5729,7 +5729,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5792,7 +5792,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "clap",
  "eyre",
@@ -5803,7 +5803,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "ahash",
  "backon",
@@ -5853,7 +5853,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5863,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5893,7 +5893,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -5904,7 +5904,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "confy",
  "humantime-serde",
@@ -5917,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "auto_impl",
  "reth-primitives",
@@ -5927,7 +5927,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "bytes",
  "derive_more",
@@ -5991,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -6013,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
@@ -6038,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6062,7 +6062,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6110,7 +6110,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -6137,7 +6137,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "aes 0.8.4",
  "alloy-primitives",
@@ -6168,7 +6168,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-payload-primitives",
@@ -6178,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "eyre",
  "futures",
@@ -6197,7 +6197,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -6210,7 +6210,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -6251,7 +6251,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "reth-chainspec",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6301,7 +6301,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-errors",
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -6348,7 +6348,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-optimism"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-consensus-common",
@@ -6387,7 +6387,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6401,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-execution-errors",
@@ -6413,7 +6413,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "eyre",
  "metrics",
@@ -6440,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6448,7 +6448,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "serde",
  "serde_json",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6479,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "bindgen",
  "cc",
@@ -6504,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "futures",
  "metrics",
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics-derive"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -6528,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6536,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -6548,7 +6548,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -6613,7 +6613,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "auto_impl",
  "futures",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "humantime-serde",
  "reth-net-banlist",
@@ -6660,7 +6660,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6680,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-db-api",
  "reth-engine-primitives",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "aquamarine",
  "backon",
@@ -6749,7 +6749,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -6810,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "eyre",
  "reth-auto-seal-consensus",
@@ -6833,7 +6833,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rpc-types-engine",
  "futures",
@@ -6856,7 +6856,7 @@ dependencies = [
 [[package]]
 name = "reth-node-optimism"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "async-trait",
  "clap",
@@ -6901,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-cli"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -6941,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "reth-basic-payload-builder",
@@ -6978,12 +6978,12 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "futures-util",
  "metrics",
@@ -7031,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-errors",
@@ -7046,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-chainspec",
  "reth-primitives",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7114,7 +7114,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -7153,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
@@ -7179,7 +7179,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7193,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-eips",
  "reth-chainspec",
@@ -7210,7 +7210,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
@@ -7264,7 +7264,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "jsonrpsee",
  "reth-engine-primitives",
@@ -7278,7 +7278,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "http 1.1.0",
  "jsonrpsee",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
@@ -7337,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-dyn-abi",
  "async-trait",
@@ -7369,7 +7369,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-sol-types",
  "derive_more",
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.1.0",
@@ -7419,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
@@ -7435,7 +7435,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7453,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -7525,7 +7525,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7538,7 +7538,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
@@ -7558,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "auto_impl",
  "reth-chainspec",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "reth-fs-util",
  "reth-primitives",
@@ -7597,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7615,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "clap",
  "eyre",
@@ -7640,7 +7640,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -7693,7 +7693,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7713,7 +7713,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=539b4e4#539b4e4262bce04657d02d1d12232e4ed19d0568"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
 dependencies = [
  "alloy-rlp",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "eip3074-instructions"
 version = "0.1.0"
-source = "git+https://github.com/emostov/eip3074-instructions.git?branch=bump-revm#bb8035a7dfdf2891f279e185d039eea6212cd5f9"
+source = "git+https://github.com/paradigmxyz/eip3074-instructions.git#5629b523b9022408b1d7a623849026704050dae8"
 dependencies = [
  "revm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,15 +57,15 @@ alloy-signer-local = { version = "0.2", features = ["mnemonic"] }
 tokio = { version = "1.21", default-features = false }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4", features = ["optimism"] }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
-reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2", features = ["optimism"] }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
 
 # misc
 clap = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2"
 clap = "4"
 eyre = "0.6.12"
 tracing = "0.1.0"
-eip3074-instructions = { git = "https://github.com/emostov/eip3074-instructions.git", branch = "bump-revm" }
+eip3074-instructions = { git = "https://github.com/paradigmxyz/eip3074-instructions.git" }
 
 # misc-testing
 rstest = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4
 clap = "4"
 eyre = "0.6.12"
 tracing = "0.1.0"
-eip3074-instructions = { git = "https://github.com/emostov/eip3074-instructions.git", rev = "0f8c5f3" }
+eip3074-instructions = { git = "https://github.com/emostov/eip3074-instructions.git", branch = "bump-revm" }
 
 # misc-testing
 rstest = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,37 +44,34 @@ incremental = false
 alphanet-node = { path = "crates/node" }
 alphanet-precompile = { path = "crates/precompile" }
 
-alloy = { git = "https://github.com/alloy-rs/alloy", rev = "5796024", features = [
+alloy = { version = "0.2", features = [
     "contract",
     "providers",
     "provider-http",
     "signers",
 ] }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "5796024" }
-alloy-signer-wallet = { git = "https://github.com/alloy-rs/alloy", rev = "5796024" }
+alloy-network = { version = "0.2" }
+alloy-signer-local = { version = "0.2", features = ["mnemonic"] }
 
 # tokio
 tokio = { version = "1.21", default-features = false }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "40d8ac0", features = ["optimism"] }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "40d8ac0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "40d8ac0" }
-reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "40d8ac0" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "40d8ac0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "40d8ac0" }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4", features = ["optimism"] }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "539b4e4" }
 
 # misc
 clap = "4"
 eyre = "0.6.12"
 tracing = "0.1.0"
-eip3074-instructions = { git = "https://github.com/paradigmxyz/eip3074-instructions.git", rev = "a9022e4" }
+eip3074-instructions = { git = "https://github.com/emostov/eip3074-instructions.git", rev = "0f8c5f3" }
 
 # misc-testing
 rstest = "0.18.2"
-
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "a28a543" }

--- a/bin/alphanet/Cargo.toml
+++ b/bin/alphanet/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 alphanet-node.workspace = true
 tracing.workspace = true
 reth.workspace = true
+reth-cli-util.workspace = true
 reth-node-optimism.workspace = true
 clap = { workspace = true, features = ["derive"] }
 

--- a/bin/alphanet/src/main.rs
+++ b/bin/alphanet/src/main.rs
@@ -37,7 +37,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[doc(hidden)]
 fn main() {
-    reth::sigsegv_handler::install();
+    reth_cli_util::sigsegv_handler::install();
 
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
     if std::env::var_os("RUST_BACKTRACE").is_none() {

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.76"
+msrv = "1.79"
 allow-dbg-in-tests = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -14,6 +14,7 @@ alphanet-precompile.workspace = true
 reth.workspace = true
 reth-node-api.workspace = true
 reth-node-optimism.workspace = true
+reth-chainspec.workspace = true
 
 eip3074-instructions.workspace = true
 

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -11,22 +11,18 @@
 //! precompiles defined by [`alphanet_precompile`].
 
 use alphanet_precompile::{bls12_381, secp256r1};
-use eip3074_instructions::{
-    context::InstructionsContext, instructions as eip3074, BoxedInstructionWithOpCode,
-};
+use eip3074_instructions::{context::InstructionsContext, instructions as eip3074};
 use reth::{
     primitives::{
         revm_primitives::{CfgEnvWithHandlerCfg, TxEnv},
-        Address, ChainSpec, Header, TransactionSigned, U256,
+        Address, Bytes, Header, TransactionSigned, U256,
     },
     revm::{
-        handler::register::EvmHandler,
-        inspector_handle_register,
-        interpreter::{opcode::InstructionTables, Host},
-        precompile::{PrecompileSpecId, PrecompileWithAddress, Precompiles},
-        Database, Evm, EvmBuilder, GetInspector,
+        handler::register::EvmHandler, inspector_handle_register, precompile::PrecompileSpecId,
+        primitives::Env, ContextPrecompiles, Database, Evm, EvmBuilder, GetInspector,
     },
 };
+use reth_chainspec::ChainSpec;
 use reth_node_api::{ConfigureEvm, ConfigureEvmEnv};
 use reth_node_optimism::OptimismEvmConfig;
 use std::sync::Arc;
@@ -35,32 +31,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Copy, Default)]
 #[non_exhaustive]
 pub struct AlphaNetEvmConfig;
-
-/// Inserts the given precompiles with address in the context precompiles.
-fn insert_precompiles<I>(precompiles: &mut Precompiles, precompiles_with_address: I)
-where
-    I: Iterator<Item = PrecompileWithAddress>,
-{
-    for precompile_with_address in precompiles_with_address {
-        precompiles.inner.insert(precompile_with_address.0, precompile_with_address.1);
-    }
-}
-
-/// Inserts the given boxed instructions with opcodes in the instructions table.
-fn insert_boxed_instructions<'a, I, H>(
-    table: &mut InstructionTables<'a, H>,
-    boxed_instructions_with_opcodes: I,
-) where
-    I: Iterator<Item = BoxedInstructionWithOpCode<'a, H>>,
-    H: Host + 'a,
-{
-    for boxed_instruction_with_opcode in boxed_instructions_with_opcodes {
-        table.insert_boxed(
-            boxed_instruction_with_opcode.opcode,
-            boxed_instruction_with_opcode.boxed_instruction,
-        );
-    }
-}
 
 impl AlphaNetEvmConfig {
     /// Sets the precompiles to the EVM handler
@@ -78,11 +48,13 @@ impl AlphaNetEvmConfig {
 
         // install the precompiles
         handler.pre_execution.load_precompiles = Arc::new(move || {
-            let mut precompiles = Precompiles::new(PrecompileSpecId::from_spec_id(spec_id)).clone();
-            insert_precompiles(&mut precompiles, secp256r1::precompiles());
-            insert_precompiles(&mut precompiles, bls12_381::precompiles());
+            let mut loaded_precompiles: ContextPrecompiles<DB> =
+                ContextPrecompiles::new(PrecompileSpecId::from_spec_id(spec_id));
 
-            precompiles.into()
+            loaded_precompiles.extend(secp256r1::precompiles());
+            loaded_precompiles.extend(bls12_381::precompiles());
+
+            loaded_precompiles
         });
     }
 
@@ -98,10 +70,13 @@ impl AlphaNetEvmConfig {
     ) where
         DB: Database,
     {
-        insert_boxed_instructions(
-            &mut handler.instruction_table,
-            eip3074::boxed_instructions(instructions_context.clone()),
-        );
+        let boxed_instruction_with_op_code =
+            eip3074::boxed_instructions(instructions_context.clone());
+
+        for b in boxed_instruction_with_op_code {
+            // revm::Boxed
+            handler.instruction_table.insert_boxed(b.opcode, b.boxed_instruction);
+        }
 
         instructions_context.clear();
     }
@@ -162,17 +137,28 @@ impl ConfigureEvm for AlphaNetEvmConfig {
 }
 
 impl ConfigureEvmEnv for AlphaNetEvmConfig {
-    fn fill_tx_env(tx_env: &mut TxEnv, transaction: &TransactionSigned, sender: Address) {
-        OptimismEvmConfig::fill_tx_env(tx_env, transaction, sender)
+    fn fill_tx_env(&self, tx_env: &mut TxEnv, transaction: &TransactionSigned, sender: Address) {
+        OptimismEvmConfig::default().fill_tx_env(tx_env, transaction, sender)
     }
 
     fn fill_cfg_env(
+        &self,
         cfg_env: &mut CfgEnvWithHandlerCfg,
         chain_spec: &ChainSpec,
         header: &Header,
         total_difficulty: U256,
     ) {
-        OptimismEvmConfig::fill_cfg_env(cfg_env, chain_spec, header, total_difficulty);
+        OptimismEvmConfig::default().fill_cfg_env(cfg_env, chain_spec, header, total_difficulty);
+    }
+
+    fn fill_tx_env_system_contract_call(
+        &self,
+        env: &mut Env,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) {
+        OptimismEvmConfig::default().fill_tx_env_system_contract_call(env, caller, contract, data)
     }
 }
 
@@ -181,8 +167,9 @@ mod tests {
     use super::*;
     use reth::primitives::{
         revm_primitives::{BlockEnv, CfgEnv, SpecId},
-        Chain, ChainSpecBuilder, ForkCondition, Genesis, Hardfork,
+        ForkCondition, Genesis, Hardfork,
     };
+    use reth_chainspec::{Chain, ChainSpecBuilder, EthereumHardfork};
 
     #[test]
     fn test_fill_cfg_and_block_env() {
@@ -192,11 +179,11 @@ mod tests {
         let chain_spec = ChainSpecBuilder::default()
             .chain(Chain::optimism_mainnet())
             .genesis(Genesis::default())
-            .with_fork(Hardfork::Frontier, ForkCondition::Block(0))
+            .with_fork(EthereumHardfork::Frontier, ForkCondition::Block(0))
             .build();
         let total_difficulty = U256::ZERO;
 
-        AlphaNetEvmConfig::fill_cfg_and_block_env(
+        AlphaNetEvmConfig::default().fill_cfg_and_block_env(
             &mut cfg_env,
             &mut block_env,
             &chain_spec,

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -166,7 +166,7 @@ mod tests {
     use super::*;
     use reth::primitives::{
         revm_primitives::{BlockEnv, CfgEnv, SpecId},
-        ForkCondition, Genesis, Hardfork,
+        ForkCondition, Genesis,
     };
     use reth_chainspec::{Chain, ChainSpecBuilder, EthereumHardfork};
 

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -74,7 +74,6 @@ impl AlphaNetEvmConfig {
             eip3074::boxed_instructions(instructions_context.clone());
 
         for b in boxed_instruction_with_op_code {
-            // revm::Boxed
             handler.instruction_table.insert_boxed(b.opcode, b.boxed_instruction);
         }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -11,7 +11,10 @@ use reth::builder::{
 use reth_node_api::FullNodeTypes;
 use reth_node_optimism::{
     args::RollupArgs,
-    node::{OptimismNetworkBuilder, OptimismPayloadBuilder, OptimismPoolBuilder},
+    node::{
+        OptimismAddOns, OptimismConsensusBuilder, OptimismNetworkBuilder, OptimismPayloadBuilder,
+        OptimismPoolBuilder,
+    },
     OpExecutorProvider, OptimismEngineTypes,
 };
 
@@ -37,6 +40,7 @@ impl AlphaNetNode {
         OptimismPayloadBuilder<AlphaNetEvmConfig>,
         OptimismNetworkBuilder,
         AlphaNetExecutorBuilder,
+        OptimismConsensusBuilder,
     >
     where
         Node: FullNodeTypes<Engine = OptimismEngineTypes>,
@@ -51,6 +55,7 @@ impl AlphaNetNode {
             ))
             .network(OptimismNetworkBuilder { disable_txpool_gossip })
             .executor(AlphaNetExecutorBuilder::default())
+            .consensus(OptimismConsensusBuilder::default())
     }
 }
 
@@ -70,11 +75,14 @@ where
         OptimismPayloadBuilder<AlphaNetEvmConfig>,
         OptimismNetworkBuilder,
         AlphaNetExecutorBuilder,
+        OptimismConsensusBuilder,
     >;
 
-    fn components_builder(self) -> Self::ComponentsBuilder {
+    type AddOns = OptimismAddOns;
+
+    fn components_builder(&self) -> Self::ComponentsBuilder {
         let Self { args } = self;
-        Self::components(args)
+        Self::components(args.clone())
     }
 }
 

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -16,6 +16,7 @@ p256 = { version = "0.13.2", features = ["ecdsa"] }
 
 [dev-dependencies]
 reth-node-api.workspace = true
+reth-chainspec.workspace = true
 eyre.workspace = true
 rstest.workspace = true
 

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -14,10 +14,12 @@ alphanet-node.workspace = true
 
 alloy.workspace = true
 alloy-network.workspace = true
-alloy-signer-wallet = { workspace = true, features = ["mnemonic"] }
+alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 
-reth.workspace = true
-reth-node-core.workspace = true
+reth = { workspace = true }
+reth-chainspec.workspace = true
+reth-node-core = { workspace = true }
+reth-node-builder = { workspace = true, features = ["test-utils"] }
 reth-primitives.workspace = true
 reth-tracing.workspace = true
 

--- a/crates/testing/src/test_suite.rs
+++ b/crates/testing/src/test_suite.rs
@@ -1,5 +1,5 @@
 use crate::wallet::Wallet;
-use alloy_network::EthereumSigner;
+use alloy_network::EthereumWallet;
 
 /// Helper struct to customize the chain spec during e2e tests
 pub(crate) struct TestSuite {
@@ -20,7 +20,7 @@ impl TestSuite {
         Self { wallet }
     }
 
-    pub(crate) fn signer(&self) -> EthereumSigner {
+    pub(crate) fn signer(&self) -> EthereumWallet {
         self.wallet.clone().into()
     }
 }

--- a/crates/testing/src/tests.rs
+++ b/crates/testing/src/tests.rs
@@ -5,15 +5,14 @@ use alloy::{
     sol,
     sol_types::SolValue,
 };
-use alloy_network::EthereumSigner;
+use alloy_network::EthereumWallet;
 use alphanet_node::node::AlphaNetNode;
 use once_cell::sync::Lazy;
-use reth::{
-    builder::{NodeBuilder, NodeHandle},
-    tasks::TaskManager,
-};
+use reth::{builder::NodeHandle, tasks::TaskManager};
+use reth_chainspec::DEV;
+use reth_node_builder::NodeBuilder;
 use reth_node_core::{args::RpcServerArgs, node_config::NodeConfig};
-use reth_primitives::{keccak256, Address, Bytes, DEV, U256};
+use reth_primitives::{keccak256, Address, Bytes, U256};
 use url::Url;
 
 sol!(
@@ -63,7 +62,7 @@ async fn test_eip3074_integration() {
     let deployer = test_suite.signer();
     let provider = ProviderBuilder::new()
         .with_recommended_fillers()
-        .signer(deployer)
+        .wallet(deployer)
         .on_http(Url::parse(&rpc_url).unwrap());
     let base_fee = provider.get_gas_price().await.unwrap();
 
@@ -86,7 +85,7 @@ async fn test_eip3074_integration() {
 
     // signer account.
     let signer_wallet = Wallet::random();
-    let signer_account: EthereumSigner = signer_wallet.clone().into();
+    let signer_account: EthereumWallet = signer_wallet.clone().into();
     let signer_address = signer_account.default_signer().address();
     let signer_balance = provider.get_balance(signer_address).await.unwrap();
     assert_eq!(signer_balance, U256::ZERO);
@@ -151,7 +150,7 @@ async fn test_eip3074_send_eth() {
     let deployer = test_suite.signer();
     let provider = ProviderBuilder::new()
         .with_recommended_fillers()
-        .signer(deployer)
+        .wallet(deployer)
         .on_http(Url::parse(&rpc_url).unwrap());
     let base_fee = provider.get_gas_price().await.unwrap();
 
@@ -164,7 +163,7 @@ async fn test_eip3074_send_eth() {
 
     // signer account.
     let signer_wallet = Wallet::new(1);
-    let signer_account: EthereumSigner = signer_wallet.clone().into();
+    let signer_account: EthereumWallet = signer_wallet.clone().into();
     let signer_address = signer_account.default_signer().address();
     let start_signer_balance = provider.get_balance(signer_address).await.unwrap();
     assert!(start_signer_balance.ne(&U256::ZERO));
@@ -174,7 +173,7 @@ async fn test_eip3074_send_eth() {
 
     // receiver account
     let receiver_wallet = Wallet::random();
-    let receiver_account: EthereumSigner = receiver_wallet.clone().into();
+    let receiver_account: EthereumWallet = receiver_wallet.clone().into();
     let receiver_address = receiver_account.default_signer().address();
     let receiver_balance = provider.get_balance(receiver_address).await.unwrap();
     assert_eq!(receiver_balance, U256::ZERO);
@@ -230,7 +229,7 @@ async fn test_bls12_381_g1_add() {
     let deployer = test_suite.signer();
     let provider = ProviderBuilder::new()
         .with_recommended_fillers()
-        .signer(deployer)
+        .wallet(deployer)
         .on_http(Url::parse(&rpc_url).unwrap());
     let base_fee = provider.get_gas_price().await.unwrap();
 

--- a/crates/testing/src/wallet.rs
+++ b/crates/testing/src/wallet.rs
@@ -1,6 +1,6 @@
 use alloy::signers::Signer;
-use alloy_network::EthereumSigner;
-use alloy_signer_wallet::{coins_bip39::English, LocalWallet, MnemonicBuilder};
+use alloy_network::EthereumWallet;
+use alloy_signer_local::{coins_bip39::English, MnemonicBuilder, PrivateKeySigner};
 use reth_primitives::{B256, U256};
 
 /// Mnemonic used to derive the test accounts
@@ -9,7 +9,7 @@ const TEST_MNEMONIC: &str = "test test test test test test test test test test t
 /// One of the accounts of the genesis allocations.
 #[derive(Clone)]
 pub(crate) struct Wallet {
-    inner: LocalWallet,
+    inner: PrivateKeySigner,
 }
 
 impl Default for Wallet {
@@ -40,7 +40,7 @@ impl Wallet {
         (signature.v().y_parity_byte() + 27, signature.r(), signature.s())
     }
 }
-impl From<Wallet> for EthereumSigner {
+impl From<Wallet> for EthereumWallet {
     fn from(val: Wallet) -> Self {
         val.inner.clone().into()
     }


### PR DESCRIPTION
relies on https://github.com/paradigmxyz/eip3074-instructions/pull/2

TODO
- [ ] point eip3074-instructions back to primary repo once https://github.com/paradigmxyz/eip3074-instructions/pull/2
 is merged