### PR TITLE
chore: bump reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "futures-utils-wasm",
  "lru",
@@ -482,7 +482,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "jsonrpsee-types 0.24.2",
+ "jsonrpsee-types",
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
@@ -503,7 +503,7 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types",
  "itertools 0.13.0",
- "jsonrpsee-types 0.24.2",
+ "jsonrpsee-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -708,7 +708,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.1.0",
+ "http",
  "rustls",
  "serde_json",
  "tokio",
@@ -1188,15 +1188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,7 +1364,7 @@ dependencies = [
  "boa_string",
  "bytemuck",
  "cfg-if",
- "dashmap",
+ "dashmap 5.5.3",
  "fast-float",
  "hashbrown 0.14.5",
  "icu_normalizer",
@@ -2207,6 +2198,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,15 +2913,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-net"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 0.2.12",
+ "http",
  "js-sys",
  "pin-project",
  "serde",
@@ -2974,7 +2979,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap 2.3.0",
  "slab",
  "tokio",
@@ -3109,17 +3114,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -3136,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -3147,7 +3141,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -3202,7 +3196,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -3220,7 +3214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "log",
@@ -3258,7 +3252,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -3671,16 +3665,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
+checksum = "0a1d83ae9ed70d8e3440db663e343a82f93913104744cd543bbcdd1dbc0e35d3"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tokio",
@@ -3689,15 +3683,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
+checksum = "5be764c8b96cdcd2974655560a1c6542a366440d47c88114894cc20c24317815"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 1.1.0",
+ "http",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -3714,24 +3708,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
+checksum = "83b772fb8aa2b511eeed75f7e19d8e5fa57be7e8202249470bf26210727399c7"
 dependencies = [
- "anyhow",
  "async-trait",
- "beef",
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -3743,9 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d90064e04fb9d7282b1c71044ea94d0bbc6eff5621c66f1a0bce9e9de7cf3ac"
+checksum = "4d5f8f6ddb09312a9592ec9e21a3ccd6f61e51730d9d56321351eff971b0fe55"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3754,7 +3746,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "rustls",
  "rustls-platform-verifier",
  "serde",
@@ -3768,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7895f186d5921065d96e16bd795e5ca89ac8356ec423fafc6e3d7cf8ec11aee4"
+checksum = "295d9b81496d1bef5bd34066d83c984388b6acb97620f468817bf46f67a1e9ab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
@@ -3781,19 +3773,18 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654afab2e92e5d88ebd8a39d6074483f3f2bfdf91c5ac57fe285e7127cdd4f51"
+checksum = "85bf179199ad809157ceaab653f71cdb67f55d9e0093a6907c5765414a6b3bbb"
 dependencies = [
- "anyhow",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-util",
  "jsonrpsee-core",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -3809,24 +3800,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
-dependencies = [
- "beef",
- "http 1.1.0",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "jsonrpsee-types"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98deeee954567f75632fa40666ac93a66d4f9f4ed4ca15bd6b7ed0720b53e761"
 dependencies = [
- "http 1.1.0",
+ "http",
  "serde",
  "serde_json",
  "thiserror",
@@ -3834,25 +3812,25 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4727ac037f834c6f04c0912cada7532dbddb54e92fbc64e33d6cb8c24af313c9"
+checksum = "4c8a01468705cf6d326b8ba9c035e71abf5cc5e10948ba46e8af151386878398"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
+checksum = "385cf0a6103a9f64987cdf0f7c9d0b08e1d7183dd952820beffb3676e7df7787"
 dependencies = [
- "http 1.1.0",
+ "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "url",
 ]
 
@@ -5558,7 +5536,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5606,8 +5584,8 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -5650,6 +5628,7 @@ dependencies = [
  "reth-node-core",
  "reth-node-ethereum",
  "reth-node-events",
+ "reth-node-metrics",
  "reth-node-optimism",
  "reth-optimism-cli",
  "reth-optimism-primitives",
@@ -5675,6 +5654,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie",
+ "reth-trie-db",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5687,8 +5667,8 @@ dependencies = [
 
 [[package]]
 name = "reth-auto-seal-consensus"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
@@ -5714,8 +5694,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -5737,8 +5717,8 @@ dependencies = [
 
 [[package]]
 name = "reth-beacon-consensus"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "futures",
  "itertools 0.13.0",
@@ -5771,8 +5751,8 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
@@ -5794,6 +5774,7 @@ dependencies = [
  "reth-stages-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-db",
  "reth-trie-parallel",
  "tokio",
  "tracing",
@@ -5801,8 +5782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-blockchain-tree-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -5812,9 +5793,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-chain-state"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
+dependencies = [
+ "auto_impl",
+ "derive_more",
+ "metrics",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "reth-chainspec",
+ "reth-errors",
+ "reth-execution-types",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-storage-api",
+ "reth-trie",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "reth-chainspec"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5834,8 +5837,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "clap",
  "eyre",
@@ -5845,8 +5848,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "ahash",
  "backon",
@@ -5859,7 +5862,6 @@ dependencies = [
  "futures",
  "human_bytes",
  "itertools 0.13.0",
- "metrics-process",
  "ratatui",
  "reth-beacon-consensus",
  "reth-chainspec",
@@ -5871,14 +5873,18 @@ dependencies = [
  "reth-db-api",
  "reth-db-common",
  "reth-downloaders",
+ "reth-ecies",
+ "reth-eth-wire",
  "reth-evm",
  "reth-exex",
  "reth-fs-util",
  "reth-network",
  "reth-network-p2p",
+ "reth-network-peers",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-events",
+ "reth-node-metrics",
  "reth-primitives",
  "reth-provider",
  "reth-prune",
@@ -5886,6 +5892,8 @@ dependencies = [
  "reth-static-file",
  "reth-static-file-types",
  "reth-trie",
+ "reth-trie-db",
+ "secp256k1",
  "serde",
  "serde_json",
  "tokio",
@@ -5895,8 +5903,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5905,8 +5913,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5920,13 +5928,14 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
+ "alloy-trie",
  "bytes",
  "modular-bitfield",
  "reth-codecs-derive",
@@ -5935,8 +5944,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -5946,8 +5955,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "confy",
  "humantime-serde",
@@ -5959,8 +5968,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "auto_impl",
  "reth-primitives",
@@ -5969,8 +5978,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -5979,8 +5988,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6002,8 +6011,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "bytes",
  "derive_more",
@@ -6033,8 +6042,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -6055,8 +6064,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
@@ -6072,6 +6081,7 @@ dependencies = [
  "reth-provider",
  "reth-stages-types",
  "reth-trie",
+ "reth-trie-db",
  "serde",
  "serde_json",
  "thiserror",
@@ -6080,8 +6090,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6104,8 +6114,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6130,8 +6140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -6152,8 +6162,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -6179,8 +6189,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "aes 0.8.4",
  "alloy-primitives",
@@ -6210,8 +6220,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
  "reth-payload-primitives",
@@ -6219,9 +6229,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-engine-tree"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
+dependencies = [
+ "futures",
+ "metrics",
+ "reth-beacon-consensus",
+ "reth-blockchain-tree",
+ "reth-blockchain-tree-api",
+ "reth-chain-state",
+ "reth-consensus",
+ "reth-db",
+ "reth-db-api",
+ "reth-engine-primitives",
+ "reth-errors",
+ "reth-evm",
+ "reth-metrics",
+ "reth-network-p2p",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-payload-validator",
+ "reth-primitives",
+ "reth-provider",
+ "reth-prune",
+ "reth-revm",
+ "reth-rpc-types",
+ "reth-stages-api",
+ "reth-tasks",
+ "reth-trie",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "reth-engine-util"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "eyre",
  "futures",
@@ -6239,8 +6284,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -6252,8 +6297,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -6277,8 +6322,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -6293,8 +6338,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -6304,9 +6349,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ethereum-engine"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
+dependencies = [
+ "futures",
+ "pin-project",
+ "reth-beacon-consensus",
+ "reth-chainspec",
+ "reth-db-api",
+ "reth-engine-tree",
+ "reth-ethereum-engine-primitives",
+ "reth-evm-ethereum",
+ "reth-network-p2p",
+ "reth-payload-builder",
+ "reth-payload-validator",
+ "reth-provider",
+ "reth-prune",
+ "reth-stages-api",
+ "reth-tasks",
+ "thiserror",
+ "tokio-stream",
+]
+
+[[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "reth-chainspec",
@@ -6323,8 +6392,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6343,8 +6412,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-errors",
@@ -6362,8 +6431,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -6372,8 +6441,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -6390,8 +6459,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
@@ -6408,11 +6477,10 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-optimism"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
- "reth-consensus-common",
  "reth-ethereum-forks",
  "reth-evm",
  "reth-execution-errors",
@@ -6429,11 +6497,13 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
+ "nybbles",
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
@@ -6443,8 +6513,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
  "reth-execution-errors",
@@ -6455,16 +6525,16 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "eyre",
+ "futures",
  "metrics",
  "reth-config",
  "reth-evm",
  "reth-exex-types",
  "reth-metrics",
- "reth-network",
  "reth-node-api",
  "reth-node-core",
  "reth-payload-builder",
@@ -6482,16 +6552,17 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
+ "reth-provider",
 ]
 
 [[package]]
 name = "reth-fs-util"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "serde",
  "serde_json",
@@ -6500,8 +6571,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6521,12 +6592,12 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
- "dashmap",
+ "dashmap 6.0.1",
  "derive_more",
  "indexmap 2.3.0",
  "parking_lot 0.12.3",
@@ -6537,8 +6608,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "bindgen",
  "cc",
@@ -6546,8 +6617,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "futures",
  "metrics",
@@ -6558,8 +6629,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics-derive"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "once_cell",
  "proc-macro2",
@@ -6570,16 +6641,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "futures-util",
  "reqwest",
@@ -6590,8 +6661,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -6640,32 +6711,40 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
+ "auto_impl",
+ "derive_more",
  "enr",
- "reth-eth-wire",
+ "futures",
+ "reth-eth-wire-types",
+ "reth-ethereum-forks",
+ "reth-network-p2p",
  "reth-network-peers",
+ "reth-network-types",
+ "reth-tokio-util",
  "serde",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "auto_impl",
  "futures",
  "reth-consensus",
  "reth-eth-wire-types",
- "reth-network-api",
  "reth-network-peers",
  "reth-primitives",
  "reth-storage-errors",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",
@@ -6673,8 +6752,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6688,12 +6767,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "humantime-serde",
+ "reth-ethereum-forks",
  "reth-net-banlist",
- "reth-network-api",
+ "reth-network-p2p",
  "reth-network-peers",
  "serde",
  "serde_json",
@@ -6702,8 +6782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6722,13 +6802,13 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-db-api",
  "reth-engine-primitives",
  "reth-evm",
- "reth-network",
+ "reth-network-api",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-provider",
@@ -6738,11 +6818,10 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "aquamarine",
- "backon",
  "confy",
  "eyre",
  "fdlimit",
@@ -6764,10 +6843,12 @@ dependencies = [
  "reth-evm",
  "reth-exex",
  "reth-network",
+ "reth-network-api",
  "reth-network-p2p",
  "reth-node-api",
  "reth-node-core",
  "reth-node-events",
+ "reth-node-metrics",
  "reth-payload-builder",
  "reth-primitives",
  "reth-provider",
@@ -6791,8 +6872,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -6802,15 +6883,7 @@ dependencies = [
  "dirs-next",
  "eyre",
  "futures",
- "http 1.1.0",
  "humantime",
- "jsonrpsee",
- "metrics",
- "metrics-exporter-prometheus",
- "metrics-process",
- "metrics-util",
- "once_cell",
- "procfs",
  "rand 0.8.5",
  "reth-chainspec",
  "reth-cli-util",
@@ -6821,7 +6894,6 @@ dependencies = [
  "reth-discv4",
  "reth-discv5",
  "reth-fs-util",
- "reth-metrics",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
@@ -6837,46 +6909,55 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-stages-types",
  "reth-storage-errors",
- "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
  "secp256k1",
  "serde_json",
  "shellexpand",
- "tikv-jemalloc-ctl",
- "tokio",
- "tower",
  "tracing",
  "vergen",
 ]
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "eyre",
+ "futures",
  "reth-auto-seal-consensus",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
+ "reth-blockchain-tree",
  "reth-consensus",
+ "reth-engine-tree",
+ "reth-ethereum-engine",
  "reth-ethereum-engine-primitives",
  "reth-ethereum-payload-builder",
  "reth-evm-ethereum",
+ "reth-exex",
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
+ "reth-node-core",
+ "reth-node-events",
  "reth-payload-builder",
  "reth-provider",
  "reth-rpc",
+ "reth-rpc-engine-api",
+ "reth-rpc-types",
+ "reth-tasks",
+ "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rpc-types-engine",
  "futures",
@@ -6897,15 +6978,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-node-metrics"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
+dependencies = [
+ "eyre",
+ "http",
+ "jsonrpsee",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-process",
+ "metrics-util",
+ "once_cell",
+ "procfs",
+ "reth-db-api",
+ "reth-metrics",
+ "reth-provider",
+ "reth-tasks",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tower",
+ "tracing",
+ "vergen",
+]
+
+[[package]]
 name = "reth-node-optimism"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "async-trait",
  "clap",
  "eyre",
  "jsonrpsee",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
  "reqwest",
  "reth-auto-seal-consensus",
@@ -6943,8 +7049,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -6983,8 +7089,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -6995,8 +7101,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "reth-basic-payload-builder",
@@ -7020,21 +7126,22 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
+ "derive_more",
  "jsonrpsee",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
- "reth-chainspec",
- "reth-errors",
  "reth-evm",
  "reth-evm-optimism",
+ "reth-network-api",
  "reth-node-api",
  "reth-primitives",
  "reth-provider",
@@ -7046,14 +7153,15 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "revm",
+ "serde",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "futures-util",
  "metrics",
@@ -7073,8 +7181,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
  "reth-errors",
@@ -7088,8 +7196,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "reth-chainspec",
  "reth-primitives",
@@ -7099,8 +7207,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7111,6 +7219,7 @@ dependencies = [
  "bytes",
  "c-kzg",
  "derive_more",
+ "k256",
  "modular-bitfield",
  "once_cell",
  "proptest",
@@ -7125,14 +7234,14 @@ dependencies = [
  "secp256k1",
  "serde",
  "tempfile",
- "thiserror-no-std",
+ "thiserror",
  "zstd",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7151,24 +7260,22 @@ dependencies = [
  "revm-primitives",
  "roaring",
  "serde",
- "thiserror-no-std",
 ]
 
 [[package]]
 name = "reth-provider"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
- "dashmap",
- "derive_more",
+ "dashmap 6.0.1",
  "itertools 0.13.0",
  "metrics",
  "parking_lot 0.12.3",
- "pin-project",
  "rayon",
  "reth-blockchain-tree-api",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-codecs",
  "reth-db",
@@ -7186,17 +7293,17 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-db",
  "revm",
  "strum",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "reth-prune"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
@@ -7221,8 +7328,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7235,8 +7342,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-eips",
  "reth-chainspec",
@@ -7247,13 +7354,12 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "revm",
- "tracing",
 ]
 
 [[package]]
 name = "reth-rpc"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
@@ -7262,11 +7368,10 @@ dependencies = [
  "async-trait",
  "derive_more",
  "futures",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "jsonrpsee",
- "jsonrpsee-types 0.23.2",
  "jsonwebtoken",
  "parking_lot 0.12.3",
  "pin-project",
@@ -7277,6 +7382,7 @@ dependencies = [
  "reth-evm",
  "reth-network-api",
  "reth-network-peers",
+ "reth-network-types",
  "reth-node-api",
  "reth-primitives",
  "reth-provider",
@@ -7290,6 +7396,7 @@ dependencies = [
  "reth-rpc-types-compat",
  "reth-tasks",
  "reth-transaction-pool",
+ "reth-trie",
  "revm",
  "revm-inspectors",
  "revm-primitives",
@@ -7306,8 +7413,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "jsonrpsee",
  "reth-engine-primitives",
@@ -7315,15 +7422,14 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-eth-api",
  "reth-rpc-types",
- "serde",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
- "http 1.1.0",
+ "http",
  "jsonrpsee",
  "metrics",
  "pin-project",
@@ -7351,12 +7457,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "async-trait",
  "jsonrpsee-core",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "metrics",
  "reth-beacon-consensus",
  "reth-chainspec",
@@ -7379,8 +7485,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-dyn-abi",
  "async-trait",
@@ -7388,11 +7494,13 @@ dependencies = [
  "dyn-clone",
  "futures",
  "jsonrpsee",
+ "jsonrpsee-types",
  "parking_lot 0.12.3",
  "reth-chainspec",
  "reth-errors",
  "reth-evm",
  "reth-execution-types",
+ "reth-network-api",
  "reth-primitives",
  "reth-provider",
  "reth-revm",
@@ -7411,14 +7519,14 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-sol-types",
  "derive_more",
  "futures",
  "jsonrpsee-core",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "metrics",
  "rand 0.8.5",
  "reth-chainspec",
@@ -7448,11 +7556,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rpc-types-engine",
- "http 1.1.0",
+ "http",
  "jsonrpsee-http-client",
  "pin-project",
  "tower",
@@ -7461,12 +7569,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
  "reth-errors",
  "reth-network-api",
  "reth-primitives",
@@ -7477,8 +7585,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -7490,13 +7598,13 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
  "alloy-serde",
- "jsonrpsee-types 0.23.2",
+ "jsonrpsee-types",
 ]
 
 [[package]]
 name = "reth-rpc-types-compat"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -7507,8 +7615,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -7533,6 +7641,7 @@ dependencies = [
  "reth-stages-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-db",
  "thiserror",
  "tokio",
  "tracing",
@@ -7540,8 +7649,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -7567,8 +7676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7580,8 +7689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
@@ -7600,8 +7709,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7612,8 +7721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "auto_impl",
  "reth-chainspec",
@@ -7629,9 +7738,10 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
+ "alloy-rlp",
  "reth-fs-util",
  "reth-primitives",
  "thiserror-no-std",
@@ -7639,8 +7749,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7657,8 +7767,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7667,8 +7777,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "clap",
  "eyre",
@@ -7682,8 +7792,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7713,8 +7823,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -7722,12 +7832,11 @@ dependencies = [
  "itertools 0.13.0",
  "metrics",
  "rayon",
- "reth-db",
- "reth-db-api",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives",
  "reth-stages-types",
+ "reth-storage-errors",
  "reth-trie-common",
  "revm",
  "tracing",
@@ -7735,8 +7844,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7754,9 +7863,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-trie-db"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
+dependencies = [
+ "alloy-rlp",
+ "auto_impl",
+ "derive_more",
+ "itertools 0.13.0",
+ "metrics",
+ "rayon",
+ "reth-db",
+ "reth-db-api",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-primitives",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie",
+ "reth-trie-common",
+ "revm",
+ "tracing",
+]
+
+[[package]]
 name = "reth-trie-parallel"
-version = "1.0.2"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.2#ffb44e6245eebd0144e8ae62f4f39203f2ea2e5f"
+version = "1.0.4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=v1.0.4#e24e4c773d7571a5a54dba7854643c02d0b0a841"
 dependencies = [
  "alloy-rlp",
  "derive_more",
@@ -7771,6 +7904,7 @@ dependencies = [
  "reth-provider",
  "reth-tasks",
  "reth-trie",
+ "reth-trie-db",
  "thiserror",
  "tokio",
  "tracing",
@@ -8638,7 +8772,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -9165,7 +9299,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -9377,7 +9511,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,7 +3962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,15 +57,15 @@ alloy-signer-local = { version = "0.2", features = ["mnemonic"] }
 tokio = { version = "1.21", default-features = false }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2", features = ["optimism"] }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
-reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.2" }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4", features = ["optimism"] }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
+reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.4" }
 
 # misc
 clap = "4"

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -84,7 +84,7 @@ impl AlphaNetEvmConfig {
 impl ConfigureEvm for AlphaNetEvmConfig {
     type DefaultExternalContext<'a> = ();
 
-    fn evm<'a, DB: Database + 'a>(&self, db: DB) -> Evm<'a, Self::DefaultExternalContext<'a>, DB> {
+    fn evm<DB: Database>(&self, db: DB) -> Evm<'_, Self::DefaultExternalContext<'_>, DB> {
         let instructions_context = InstructionsContext::default();
         EvmBuilder::default()
             .with_db(db)
@@ -106,9 +106,9 @@ impl ConfigureEvm for AlphaNetEvmConfig {
             .build()
     }
 
-    fn evm_with_inspector<'a, DB, I>(&self, db: DB, inspector: I) -> Evm<'a, I, DB>
+    fn evm_with_inspector<DB, I>(&self, db: DB, inspector: I) -> Evm<'_, I, DB>
     where
-        DB: Database + 'a,
+        DB: Database,
         I: GetInspector<DB>,
     {
         let instructions_context = InstructionsContext::default();
@@ -133,6 +133,8 @@ impl ConfigureEvm for AlphaNetEvmConfig {
             .append_handler_register(inspector_handle_register)
             .build()
     }
+
+    fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a> {}
 }
 
 impl ConfigureEvmEnv for AlphaNetEvmConfig {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -45,7 +45,7 @@ impl AlphaNetNode {
     where
         Node: FullNodeTypes<Engine = OptimismEngineTypes>,
     {
-        let RollupArgs { disable_txpool_gossip, compute_pending_block, .. } = args;
+        let RollupArgs { disable_txpool_gossip, compute_pending_block, discovery_v4, .. } = args;
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(OptimismPoolBuilder::default())
@@ -53,7 +53,10 @@ impl AlphaNetNode {
                 compute_pending_block,
                 AlphaNetEvmConfig::default(),
             ))
-            .network(OptimismNetworkBuilder { disable_txpool_gossip })
+            .network(OptimismNetworkBuilder {
+                disable_txpool_gossip,
+                disable_discovery_v4: !discovery_v4,
+            })
             .executor(AlphaNetExecutorBuilder::default())
             .consensus(OptimismConsensusBuilder::default())
     }

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -29,7 +29,7 @@
 //! impl ConfigureEvm for AlphaNetEvmConfig {
 //!     type DefaultExternalContext<'a> = ();
 //!
-//!     fn evm<'a, DB: Database + 'a>(&self, db: DB) -> Evm<'a, (), DB> {
+//!     fn evm<DB: Database>(&self, db: DB) -> Evm<'_, (), DB> {
 //!         EvmBuilder::default()
 //!             .with_db(db)
 //!             .append_handler_register(|handler| {
@@ -44,6 +44,8 @@
 //!             })
 //!             .build()
 //!     }
+//!
+//!     fn default_external_context<'a>(&self) -> Self::DefaultExternalContext<'a> {}
 //! }
 //!
 //! impl ConfigureEvmEnv for AlphaNetEvmConfig {


### PR DESCRIPTION
This updates reth to `1.0.4` and updates the `ConfigureEvm` implementation