### PR TITLE
chore: sync profiles with reth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["bin/alphanet/", "crates/node", "crates/precompile", "crates/testing"]
+members = [
+    "bin/alphanet/",
+    "crates/node",
+    "crates/precompile",
+    "crates/testing",
+]
 default-members = ["bin/alphanet/"]
 resolver = "2"
 
@@ -33,11 +38,19 @@ missing_docs = "warn"
 all = "warn"
 
 [profile.release]
-strip = "debuginfo"
+opt-level = 3
 lto = "thin"
+debug = "line-tables-only"
+strip = true
 panic = "unwind"
-codegen-units = 1
-incremental = false
+codegen-units = 16
+
+# Use the `--profile profiling` flag to show symbols in release mode.
+# e.g. `cargo build --profile profiling`
+[profile.profiling]
+inherits = "release"
+debug = 2
+strip = false
 
 [workspace.dependencies]
 # alphanet
@@ -57,7 +70,9 @@ alloy-signer-local = { version = "0.2", features = ["mnemonic"] }
 tokio = { version = "1.21", default-features = false }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.5", features = ["optimism"] }
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.5", features = [
+    "optimism",
+] }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.5" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.5" }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.0.5" }


### PR DESCRIPTION
Syncs the `release` profile from Reth and adds the `profiling` profile from Reth as well