### PR TITLE
feat: activate prague always

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,12 +779,16 @@ version = "0.0.0"
 dependencies = [
  "alphanet-precompile",
  "eyre",
+ "once_cell",
  "reth-chainspec",
+ "reth-cli",
  "reth-node-api",
  "reth-node-builder",
+ "reth-node-core",
  "reth-node-optimism",
  "reth-primitives",
  "reth-revm",
+ "serde_json",
 ]
 
 [[package]]
@@ -793,7 +797,6 @@ version = "0.0.0"
 dependencies = [
  "eyre",
  "p256",
- "reth-chainspec",
  "reth-node-api",
  "reth-primitives",
  "reth-revm",
@@ -810,7 +813,6 @@ dependencies = [
  "alphanet-node",
  "once_cell",
  "reth",
- "reth-chainspec",
  "reth-node-builder",
  "reth-node-core",
  "reth-primitives",
@@ -885,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
 
 [[package]]
 name = "aquamarine"
@@ -3183,9 +3185,9 @@ checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "iri-string"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5f6c2df22c009ac44f6f1499308e7a3ac7ba42cd2378475cc691510e1eef1b"
+checksum = "3e0f755bd3806e06ad4f366f92639415d99a339a2c7ecf8c26ccea2097c11cb6"
 dependencies = [
  "memchr",
  "serde",
@@ -3270,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec465b607a36dc5dd45d48b7689bc83f679f66a3ac6b6b21cc787a11e0f8685"
+checksum = "8fd1ead9fb95614e8dc5556d12a8681c2f6d352d0c1d3efc8708c7ccbba47bc6"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3288,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f0977f9c15694371b8024c35ab58ca043dbbf4b51ccb03db8858a021241df1"
+checksum = "89841d4f03a14c055eb41d4f41901819573ef948e8ee0d5c86466fd286b2ce7f"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -3313,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e942c55635fbf5dc421938b8558a8141c7e773720640f4f1dbe1f4164ca4e221"
+checksum = "ff79651479f69ada7bda604ef2acf3f1aa50755d97cc36d25ff04c2664f9d96f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3340,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33774602df12b68a2310b38a535733c477ca4a498751739f89fe8dbbb62ec4c"
+checksum = "68ed8b301b19f4dad8ddc66ed956a70fc227def5c19b3898e0a29ce8f0edee06"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3365,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b07a2daf52077ab1b197aea69a5c990c060143835bf04c77070e98903791715"
+checksum = "a0d4c6bec4909c966f59f52db3655c0e9d4685faae8b49185973d9d7389bb884"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -3378,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038fb697a709bec7134e9ccbdbecfea0e2d15183f7140254afef7c5610a3f488"
+checksum = "ebe2198e5fd96cf2153ecc123364f699b6e2151317ea09c7bf799c43c2fe1415"
 dependencies = [
  "futures-util",
  "http",
@@ -3405,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b67d6e008164f027afbc2e7bb79662650158d26df200040282d2aa1cbb093b"
+checksum = "531e386460425e49679587871a056f2895a47dade21457324ad1262cd78ef6d9"
 dependencies = [
  "http",
  "serde",
@@ -3417,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0470d0ae043ffcb0cd323797a631e637fb4b55fe3eaa6002934819458bba62a7"
+checksum = "5a2d2206c8f04c6b79a11bd1d92d6726b6f7fd3dec57c91e07fa53e867268bbb"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3428,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bf67d1132f88edf4a4f8cff474cf01abb2be203004a2b8e11c2b20795b99e"
+checksum = "87bc869e143d430e748988261d19b630e8f1692074e68f1a7f0eb4c521d2fc58"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -3479,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422fbc7ff2f2f5bdffeb07718e5a5324dca72b0c9293d50df4026652385e3314"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -3597,7 +3599,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
 ]
 
 [[package]]
@@ -4371,7 +4373,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4889,9 +4891,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -5016,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -5085,7 +5087,7 @@ dependencies = [
 [[package]]
 name = "reth-auto-seal-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "futures-util",
@@ -5114,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -5137,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "futures",
@@ -5171,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -5203,7 +5205,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -5215,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "auto_impl",
  "derive_more",
@@ -5237,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5259,7 +5261,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "clap",
  "eyre",
@@ -5269,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "ahash",
  "alloy-primitives",
@@ -5325,7 +5327,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -5335,7 +5337,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5350,7 +5352,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5367,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -5378,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -5392,7 +5394,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -5403,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -5414,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5437,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "bytes",
  "derive_more",
@@ -5468,7 +5470,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -5491,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -5519,7 +5521,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -5533,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5557,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5581,7 +5583,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -5603,7 +5605,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -5630,7 +5632,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -5661,7 +5663,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-chainspec",
  "reth-execution-types",
@@ -5674,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "futures",
  "pin-project",
@@ -5696,7 +5698,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "futures",
  "metrics",
@@ -5722,6 +5724,7 @@ dependencies = [
  "reth-stages-api",
  "reth-tasks",
  "reth-trie",
+ "reth-trie-parallel",
  "thiserror",
  "tokio",
  "tracing",
@@ -5730,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "eyre",
  "futures",
@@ -5760,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -5773,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -5798,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -5814,7 +5817,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -5826,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "reth-chain-state",
@@ -5845,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5865,7 +5868,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-chain-state",
@@ -5886,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -5896,7 +5899,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -5916,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
@@ -5934,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-optimism"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -5956,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5972,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-chainspec",
  "reth-execution-errors",
@@ -5984,7 +5987,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "eyre",
  "futures",
@@ -6011,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "reth-primitives",
@@ -6021,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "serde",
  "serde_json",
@@ -6031,7 +6034,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -6051,7 +6054,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6072,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -6088,7 +6091,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "bindgen",
  "cc",
@@ -6097,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "futures",
  "metrics",
@@ -6109,7 +6112,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics-derive"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6120,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
 ]
@@ -6128,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6141,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -6189,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -6212,7 +6215,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "auto_impl",
  "derive_more",
@@ -6230,7 +6233,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6245,7 +6248,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -6259,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6276,7 +6279,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-engine-primitives",
  "reth-evm",
@@ -6293,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -6354,7 +6357,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -6408,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "eyre",
  "reth-auto-seal-consensus",
@@ -6432,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -6455,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "eyre",
  "http",
@@ -6479,7 +6482,7 @@ dependencies = [
 [[package]]
 name = "reth-node-optimism"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -6524,7 +6527,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -6534,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6549,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-cli"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6591,7 +6594,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "reth-chainspec",
@@ -6605,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6633,12 +6636,12 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-types",
@@ -6672,7 +6675,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "futures-util",
  "metrics",
@@ -6694,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-chain-state",
  "reth-chainspec",
@@ -6710,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-chainspec",
  "reth-primitives",
@@ -6721,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6757,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6781,7 +6784,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -6821,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
@@ -6848,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6862,7 +6865,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "reth-chainspec",
  "reth-consensus-common",
@@ -6877,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -6934,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
@@ -6950,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-network",
  "http",
@@ -6984,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7014,7 +7017,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-rpc",
@@ -7052,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -7091,7 +7094,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -7104,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee-core",
@@ -7120,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7143,7 +7146,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7156,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -7190,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "aquamarine",
@@ -7218,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7231,7 +7234,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.3",
@@ -7253,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -7265,7 +7268,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -7283,7 +7286,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7295,7 +7298,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -7313,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -7323,7 +7326,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "clap",
  "eyre",
@@ -7338,7 +7341,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7372,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7395,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7415,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -7439,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.0.6"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=c1b5fbb#c1b5fbbc7fe3f70ee025c4600e68235ed44252c4"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=ef1d9e7#ef1d9e7a038a34563522c19f796c01773fb0ea0b"
 dependencies = [
  "alloy-rlp",
  "derive_more",
@@ -7730,9 +7733,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -7922,9 +7925,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -8123,9 +8126,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
 dependencies = [
  "cc",
  "cfg-if",
@@ -9048,9 +9051,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,37 +70,40 @@ alloy-signer-local = { version = "0.3", features = ["mnemonic"] }
 tokio = { version = "1.21", default-features = false }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb", features = [
+reth = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7", features = [
     "optimism",
 ] }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb", features = [
+reth-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7", features = [
     "optimism",
 ] }
-reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb", features = [
+reth-node-optimism = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7", features = [
     "optimism",
 ] }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb", features = [
+reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7", features = [
     "optimism",
 ] }
-reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb", features = [
+reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7", features = [
     "optimism",
 ] }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb", features = [
+reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7", features = [
     "optimism",
 ] }
-reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7", features = [
     "optimism",
 ] }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "c1b5fbb" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "ef1d9e7" }
 
 # misc
 clap = "4"
 eyre = "0.6.12"
 tracing = "0.1.0"
+serde_json = "1"
+once_cell = "1.19"
 
 # misc-testing
 rstest = "0.18.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ COPY LICENSE-* ./
 ADD etc/alphanet-genesis.json ./etc/alphanet-genesis.json
 
 EXPOSE 30303 30303/udp 9001 8545 9000 8546
-ENTRYPOINT ["/usr/local/bin/alphanet", "--chain", "./etc/alphanet-genesis.json"]
+ENTRYPOINT ["/usr/local/bin/alphanet"]

--- a/bin/alphanet/src/main.rs
+++ b/bin/alphanet/src/main.rs
@@ -23,10 +23,10 @@
 //! - `min-debug-logs`: Disables all logs below `debug` level.
 //! - `min-trace-logs`: Disables all logs below `trace` level.
 
-use alphanet_node::node::AlphaNetNode;
+use alphanet_node::{chainspec::AlphanetChainSpecParser, node::AlphaNetNode};
 use clap::Parser;
 use reth_node_optimism::args::RollupArgs;
-use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
+use reth_optimism_cli::Cli;
 use reth_optimism_rpc::eth::rpc::SequencerClient;
 
 // We use jemalloc for performance reasons.
@@ -45,7 +45,7 @@ fn main() {
     }
 
     if let Err(err) =
-        Cli::<OpChainSpecParser, RollupArgs>::parse().run(|builder, rollup_args| async move {
+        Cli::<AlphanetChainSpecParser, RollupArgs>::parse().run(|builder, rollup_args| async move {
             let node = builder
                 .node(AlphaNetNode::new(rollup_args.clone()))
                 .extend_rpc_modules(move |ctx| {

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -11,12 +11,16 @@ categories.workspace = true
 
 [dependencies]
 alphanet-precompile.workspace = true
+once_cell.workspace = true
+reth-cli.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
+reth-node-core.workspace = true
 reth-node-optimism.workspace = true
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-revm.workspace = true
+serde_json.workspace = true
 
 eyre.workspace = true
 

--- a/crates/node/src/chainspec.rs
+++ b/crates/node/src/chainspec.rs
@@ -1,0 +1,135 @@
+//! Alphanet chainspec parsing logic.
+
+use once_cell::sync::Lazy;
+use reth_chainspec::{
+    BaseFeeParams, BaseFeeParamsKind, Chain, ChainHardforks, ChainSpec, EthereumHardfork,
+    ForkCondition, OptimismHardfork,
+};
+use reth_cli::chainspec::ChainSpecParser;
+use reth_node_core::args::utils::parse_custom_chain_spec;
+use reth_primitives::{b256, constants::ETHEREUM_BLOCK_GAS_LIMIT, U256};
+use std::sync::Arc;
+
+/// Alphanet forks.
+pub static ALPHANET_FORKS: Lazy<ChainHardforks> = Lazy::new(|| {
+    ChainHardforks::new(vec![
+        (EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Homestead.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Dao.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Tangerine.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::SpuriousDragon.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Byzantium.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Constantinople.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Petersburg.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Istanbul.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::Berlin.boxed(), ForkCondition::Block(0)),
+        (EthereumHardfork::London.boxed(), ForkCondition::Block(0)),
+        (
+            EthereumHardfork::Paris.boxed(),
+            ForkCondition::TTD { fork_block: None, total_difficulty: U256::ZERO },
+        ),
+        (EthereumHardfork::Shanghai.boxed(), ForkCondition::Timestamp(0)),
+        (EthereumHardfork::Cancun.boxed(), ForkCondition::Timestamp(0)),
+        (OptimismHardfork::Regolith.boxed(), ForkCondition::Timestamp(0)),
+        (OptimismHardfork::Bedrock.boxed(), ForkCondition::Block(0)),
+        (OptimismHardfork::Ecotone.boxed(), ForkCondition::Timestamp(0)),
+        (OptimismHardfork::Canyon.boxed(), ForkCondition::Timestamp(0)),
+        (EthereumHardfork::Prague.boxed(), ForkCondition::Timestamp(0)),
+    ])
+});
+
+/// Alphanet dev testnet specification.
+pub static ALPHANET_DEV: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
+    ChainSpec {
+        chain: Chain::dev(),
+        genesis: serde_json::from_str(include_str!("../../../etc/alphanet-genesis.json"))
+            .expect("Can't deserialize alphanet genesis json"),
+        genesis_hash: Some(b256!(
+            "2f980576711e3617a5e4d83dd539548ec0f7792007d505a3d2e9674833af2d7c"
+        )),
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks: ALPHANET_FORKS.clone(),
+        base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
+        deposit_contract: None,
+        ..Default::default()
+    }
+    .into()
+});
+
+/// Alphanet main chain specification.
+pub static ALPHANET_MAINNET: Lazy<Arc<ChainSpec>> = Lazy::new(|| {
+    ChainSpec {
+        chain: Chain::optimism_mainnet(),
+        // genesis contains empty alloc field because state at first bedrock block is imported
+        // manually from trusted source
+        genesis: serde_json::from_str(include_str!("../../../etc/alphanet-genesis.json"))
+            .expect("Can't deserialize alphanet genesis json"),
+        genesis_hash: Some(b256!(
+            "2f980576711e3617a5e4d83dd539548ec0f7792007d505a3d2e9674833af2d7c"
+        )),
+        paris_block_and_final_difficulty: Some((0, U256::from(0))),
+        hardforks: ALPHANET_FORKS.clone(),
+        base_fee_params: BaseFeeParamsKind::Variable(
+            vec![
+                (EthereumHardfork::London.boxed(), BaseFeeParams::optimism()),
+                (OptimismHardfork::Canyon.boxed(), BaseFeeParams::optimism_canyon()),
+            ]
+            .into(),
+        ),
+        max_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
+        prune_delete_limit: 10000,
+        ..Default::default()
+    }
+    .into()
+});
+
+/// Alphanet chain specification parser.
+#[derive(Debug, Clone, Default)]
+pub struct AlphanetChainSpecParser;
+
+impl ChainSpecParser for AlphanetChainSpecParser {
+    type ChainSpec = ChainSpec;
+
+    const SUPPORTED_CHAINS: &'static [&'static str] = &["alphanet", "dev"];
+
+    fn parse(s: &str) -> eyre::Result<Arc<Self::ChainSpec>> {
+        Ok(match s {
+            "alphanet" => ALPHANET_MAINNET.clone(),
+            "dev" => ALPHANET_DEV.clone(),
+            s => {
+                let mut chainspec = parse_custom_chain_spec(s)?;
+
+                // NOTE(onbjerg): This is a temporary workaround until we figure out a better way to
+                // activate Prague based on a custom fork name. Currently there does not seem to be
+                // a good way to do it.
+                chainspec.hardforks.insert(EthereumHardfork::Prague, ForkCondition::Timestamp(0));
+
+                Arc::new(chainspec)
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use reth_chainspec::EthereumHardforks;
+    use reth_cli::chainspec::ChainSpecParser;
+
+    use super::AlphanetChainSpecParser;
+
+    #[test]
+    fn chainspec_parser_adds_prague() {
+        let mut chainspec_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        chainspec_path.push("../../etc/alphanet-genesis.json");
+
+        let chain_spec = AlphanetChainSpecParser::parse(&chainspec_path.to_string_lossy())
+            .expect("could not parse chainspec");
+
+        assert!(
+            chain_spec.is_prague_active_at_timestamp(0),
+            "prague should be active at timestamp 0"
+        );
+    }
+}

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -28,7 +28,7 @@ use reth_revm::{
 use std::sync::Arc;
 
 /// Custom EVM configuration
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct AlphaNetEvmConfig {
     chain_spec: Arc<ChainSpec>,
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -15,5 +15,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(unused_crate_dependencies)]
 
+pub mod chainspec;
 pub mod evm;
 pub mod node;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -112,7 +112,7 @@ where
         ctx: &BuilderContext<Node>,
     ) -> eyre::Result<(Self::EVM, Self::Executor)> {
         let chain_spec = ctx.chain_spec();
-        let evm_config = AlphaNetEvmConfig::default();
+        let evm_config = AlphaNetEvmConfig::new(chain_spec.clone());
         let executor = OpExecutorProvider::new(chain_spec, evm_config.clone());
 
         Ok((evm_config, executor))

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -11,11 +11,11 @@ categories.workspace = true
 
 [dependencies]
 reth-revm.workspace = true
+
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 
 [dev-dependencies]
 reth-node-api.workspace = true
-reth-chainspec.workspace = true
 reth-primitives.workspace = true
 eyre.workspace = true
 rstest.workspace = true

--- a/crates/precompile/src/secp256r1.rs
+++ b/crates/precompile/src/secp256r1.rs
@@ -10,7 +10,6 @@
 //! The precompile can be inserted in a custom EVM like this:
 //! ```
 //! use alphanet_precompile::secp256r1;
-//! use reth_chainspec::ChainSpec;
 //! use reth_node_api::{ConfigureEvm, ConfigureEvmEnv};
 //! use reth_primitives::{TransactionSigned, U256};
 //! use reth_revm::{

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -17,7 +17,6 @@ alloy-network.workspace = true
 alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 
 reth = { workspace = true }
-reth-chainspec.workspace = true
 reth-node-core = { workspace = true }
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 reth-primitives.workspace = true


### PR DESCRIPTION
Adds a custom chainspec parser that just inserts Prague as a hardfork from timestamp 0, always. This logic should be replaced with a custom hardfork name that we parse and map to Prague, once that is possible.

This can be reviewed as its own thing, but requires #111 