### PR TITLE
fix: include dev genesis in dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@
 
 # include L2 genesis files
 !/etc/alphanet-genesis.json
+!/etc/dev-genesis.json
 
 # include example files
 !/examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ COPY --from=builder /app/alphanet /usr/local/bin
 # Copy licenses
 COPY LICENSE-* ./
 
-# Copy the genesis file
+# Copy the genesis files
+ADD etc/dev-genesis.json ./etc/dev-genesis.json
 ADD etc/alphanet-genesis.json ./etc/alphanet-genesis.json
 
 EXPOSE 30303 30303/udp 9001 8545 9000 8546


### PR DESCRIPTION
The dev genesis was not being included in the dockerfile, leading to a build failure

Follow up on #120 