### PR TITLE
fix: push tag and latest for non-alpha versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,8 +37,8 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
       - name: Build and push image, tag as "latest"
-        if: ${{ contains(github.event.ref, '-alpha') }}
+        if: ${{ ! contains(github.event.ref, '-alpha') }}
         run: make docker-build-push-latest
       - name: Build and push image
-        if: ${{ ! contains(github.event.ref, '-alpha') }}
+        if: ${{ contains(github.event.ref, '-alpha') }}
         run: make docker-build-push


### PR DESCRIPTION
We should no longer tag `-alpha` version images as `latest`