### PR TITLE
chore: spin up 2 nodes by default

### DIFF
--- a/etc/kurtosis.yaml
+++ b/etc/kurtosis.yaml
@@ -6,6 +6,7 @@ optimism_package:
   participants:
     - el_type: op-reth
       el_image: ghcr.io/paradigmxyz/alphanet:latest
+      count: 2
   network_params:
     network_id: "41144114"
     seconds_per_slot: 1


### PR DESCRIPTION
This catches some coordination issues, e.g. payload builder issues or P2P issues.