### PR TITLE
chore(cli): use reth_cli_util allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,6 @@ dependencies = [
  "reth-optimism-node",
  "reth-optimism-rpc",
  "reth-provider",
- "tikv-jemallocator",
  "tracing",
 ]
 

--- a/bin/alphanet/Cargo.toml
+++ b/bin/alphanet/Cargo.toml
@@ -22,16 +22,13 @@ reth-optimism-rpc.workspace = true
 reth-provider.workspace = true
 clap = { workspace = true, features = ["derive"] }
 
-[target.'cfg(not(windows))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
-
 [features]
 default = ["jemalloc"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak"]
 
-jemalloc = ["dep:tikv-jemallocator", "reth-cli-util/jemalloc"]
-jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
+jemalloc = ["reth-cli-util/jemalloc"]
+jemalloc-prof = ["jemalloc", "reth-cli-util/jemalloc-prof"]
 
 min-error-logs = ["tracing/release_max_level_error"]
 min-warn-logs = ["tracing/release_max_level_warn"]

--- a/bin/alphanet/Cargo.toml
+++ b/bin/alphanet/Cargo.toml
@@ -30,7 +30,7 @@ default = ["jemalloc"]
 
 asm-keccak = ["reth-optimism-cli/asm-keccak"]
 
-jemalloc = ["dep:tikv-jemallocator"]
+jemalloc = ["dep:tikv-jemallocator", "reth-cli-util/jemalloc"]
 jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
 
 min-error-logs = ["tracing/release_max_level_error"]

--- a/bin/alphanet/src/main.rs
+++ b/bin/alphanet/src/main.rs
@@ -31,11 +31,8 @@ use reth_optimism_node::{args::RollupArgs, node::OptimismAddOns};
 use reth_optimism_rpc::sequencer::SequencerClient;
 use reth_provider::providers::BlockchainProvider2;
 
-// We use jemalloc for performance reasons.
-#[cfg(all(feature = "jemalloc", unix))]
-#[doc(hidden)]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
 #[doc(hidden)]
 fn main() {


### PR DESCRIPTION
This now uses the `reth_cli_util` allocator, instead of manually pulling in jemalloc