### PR TITLE
fix: set max fee per gas correctly

### DIFF
--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -274,7 +274,7 @@ where
             LoadFee::eip1559_fees(&self.inner.eth_api, None, None)
                 .await
                 .map_err(|_| AlphaNetWalletError::InvalidTransactionRequest)?;
-        request.max_fee_per_gas = Some(max_fee_per_gas.to());
+        request.max_fee_per_gas = Some((max_fee_per_gas + max_priority_fee_per_gas).to());
         request.max_priority_fee_per_gas = Some(max_priority_fee_per_gas.to());
         request.gas_price = None;
 


### PR DESCRIPTION
The description for `LoadFee::eip1559_fees` is misleading, it does not return `max_fee_per_gas` and `max_priority_fee_per_gas`, it returns `base_fee` and `max_priority_fee_per_gas`.

Will fix this upstream as well.